### PR TITLE
Allow unknown schema keys across protocol and API (fix #2)

### DIFF
--- a/apps/server/src/http-schemas.ts
+++ b/apps/server/src/http-schemas.ts
@@ -6,7 +6,7 @@ export const SetModeBodySchema = z
     ownerClientId: z.string().optional(),
     collaborationMode: CollaborationModeSchema
   })
-  .strict();
+  .passthrough();
 
 export const StartThreadBodySchema = z
   .object({
@@ -18,7 +18,7 @@ export const StartThreadBodySchema = z
     approvalPolicy: z.string().optional(),
     ephemeral: z.boolean().optional()
   })
-  .strict();
+  .passthrough();
 
 export const SendMessageBodySchema = z
   .object({
@@ -27,7 +27,7 @@ export const SendMessageBodySchema = z
     cwd: z.string().optional(),
     isSteering: z.boolean().optional()
   })
-  .strict();
+  .passthrough();
 
 export const SubmitUserInputBodySchema = z
   .object({
@@ -35,32 +35,32 @@ export const SubmitUserInputBodySchema = z
     requestId: z.number().int().nonnegative(),
     response: z.unknown()
   })
-  .strict();
+  .passthrough();
 
 export const InterruptBodySchema = z
   .object({
     ownerClientId: z.string().optional()
   })
-  .strict();
+  .passthrough();
 
 export const TraceStartBodySchema = z
   .object({
     label: z.string().min(1).max(120)
   })
-  .strict();
+  .passthrough();
 
 export const TraceMarkBodySchema = z
   .object({
     note: z.string().max(500)
   })
-  .strict();
+  .passthrough();
 
 export const ReplayBodySchema = z
   .object({
     entryId: z.string().min(1),
     waitForResponse: z.boolean().optional()
   })
-  .strict();
+  .passthrough();
 
 export function parseBody<Schema extends z.ZodTypeAny>(
   schema: Schema,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -33,16 +33,24 @@ const HealthResponseSchema = z
       })
       .passthrough()
   })
-  .strict();
+  .passthrough();
 
-const LiveStateResponseSchema = z
+const LiveStateResponseSchema: z.ZodObject<
+  {
+    ok: z.ZodLiteral<true>;
+    threadId: z.ZodString;
+    ownerClientId: z.ZodNullable<z.ZodString>;
+    conversationState: z.ZodUnion<[typeof ThreadConversationStateSchema, z.ZodNull]>;
+  },
+  "passthrough"
+> = z
   .object({
     ok: z.literal(true),
     threadId: z.string(),
     ownerClientId: z.string().nullable(),
     conversationState: z.union([ThreadConversationStateSchema, z.null()])
   })
-  .strict();
+  .passthrough();
 
 const StreamEventsResponseSchema = z
   .object({
@@ -51,7 +59,7 @@ const StreamEventsResponseSchema = z
     ownerClientId: z.string().nullable(),
     events: z.array(z.unknown())
   })
-  .strict();
+  .passthrough();
 
 const CreateThreadResponseSchema = z
   .object({
@@ -59,7 +67,7 @@ const CreateThreadResponseSchema = z
     threadId: z.string()
   })
   .merge(AppServerStartThreadResponseSchema)
-  .strict();
+  .passthrough();
 
 const TraceStatusSchema = z
   .object({
@@ -85,7 +93,7 @@ const TraceStatusSchema = z
       })
     )
   })
-  .strict();
+  .passthrough();
 
 const HistoryListSchema = z
   .object({
@@ -101,7 +109,7 @@ const HistoryListSchema = z
       })
     )
   })
-  .strict();
+  .passthrough();
 
 const HistoryDetailSchema = z
   .object({
@@ -109,7 +117,7 @@ const HistoryDetailSchema = z
     entry: HistoryListSchema.shape.history.element,
     fullPayload: z.unknown()
   })
-  .strict();
+  .passthrough();
 
 async function request(path: string, init?: RequestInit): Promise<unknown> {
   const response = await fetch(path, init);

--- a/packages/codex-protocol/README.md
+++ b/packages/codex-protocol/README.md
@@ -46,9 +46,9 @@ All helpers throw `ProtocolValidationError` with issue paths.
 
 ## Strictness Policy
 
-- Schemas use `.strict()` by default.
-- Unknown fields are rejected unless explicitly allowed.
-- No fallback parsing and no shape coercion.
+- Schemas use `.passthrough()` by default.
+- Unknown fields are allowed and preserved.
+- Required known fields are still validated with exact types.
 
 ## Development
 

--- a/packages/codex-protocol/src/app-server.ts
+++ b/packages/codex-protocol/src/app-server.ts
@@ -17,7 +17,7 @@ export const AppServerThreadListItemSchema = z
     gitInfo: z.unknown().nullable().optional(),
     turns: z.array(z.unknown()).optional()
   })
-  .strict();
+  .passthrough();
 
 export const AppServerListThreadsResponseSchema = z
   .object({
@@ -26,20 +26,25 @@ export const AppServerListThreadsResponseSchema = z
     pages: NonNegativeIntSchema.optional(),
     truncated: z.boolean().optional()
   })
-  .strict();
+  .passthrough();
 
-export const AppServerReadThreadResponseSchema = z
+export const AppServerReadThreadResponseSchema: z.ZodObject<
+  {
+    thread: typeof ThreadConversationStateSchema;
+  },
+  "passthrough"
+> = z
   .object({
     thread: ThreadConversationStateSchema
   })
-  .strict();
+  .passthrough();
 
 export const AppServerModelReasoningEffortSchema = z
   .object({
     reasoningEffort: NonEmptyStringSchema,
     description: z.string()
   })
-  .strict();
+  .passthrough();
 
 export const AppServerModelSchema = z
   .object({
@@ -54,14 +59,14 @@ export const AppServerModelSchema = z
     supportsPersonality: z.boolean(),
     isDefault: z.boolean()
   })
-  .strict();
+  .passthrough();
 
 export const AppServerListModelsResponseSchema = z
   .object({
     data: z.array(AppServerModelSchema),
     nextCursor: z.union([z.string(), z.null()])
   })
-  .strict();
+  .passthrough();
 
 export const AppServerCollaborationModeListItemSchema = z
   .object({
@@ -71,13 +76,13 @@ export const AppServerCollaborationModeListItemSchema = z
     reasoning_effort: NullableNonEmptyStringSchema,
     developer_instructions: z.union([z.string(), z.null()])
   })
-  .strict();
+  .passthrough();
 
 export const AppServerCollaborationModeListResponseSchema = z
   .object({
     data: z.array(AppServerCollaborationModeListItemSchema)
   })
-  .strict();
+  .passthrough();
 
 export const AppServerStartThreadRequestSchema = z
   .object({
@@ -89,7 +94,7 @@ export const AppServerStartThreadRequestSchema = z
     approvalPolicy: z.string().optional(),
     ephemeral: z.boolean().optional()
   })
-  .strict();
+  .passthrough();
 
 export const AppServerStartThreadResponseSchema = z
   .object({
@@ -101,7 +106,7 @@ export const AppServerStartThreadResponseSchema = z
     sandbox: z.unknown().optional(),
     reasoningEffort: z.string().optional()
   })
-  .strict();
+  .passthrough();
 
 export const AppServerSendUserMessageItemSchema = z
   .object({
@@ -110,25 +115,25 @@ export const AppServerSendUserMessageItemSchema = z
       .object({
         text: z.string()
       })
-      .strict()
+      .passthrough()
   })
-  .strict();
+  .passthrough();
 
 export const AppServerSendUserMessageRequestSchema = z
   .object({
     conversationId: NonEmptyStringSchema,
     items: z.array(AppServerSendUserMessageItemSchema).min(1)
   })
-  .strict();
+  .passthrough();
 
-export const AppServerSendUserMessageResponseSchema = z.object({}).strict();
+export const AppServerSendUserMessageResponseSchema = z.object({}).passthrough();
 
 export const AppServerSetModeRequestSchema = z
   .object({
     conversationId: NonEmptyStringSchema,
     collaborationMode: CollaborationModeSchema
   })
-  .strict();
+  .passthrough();
 
 export type AppServerListThreadsResponse = z.infer<typeof AppServerListThreadsResponseSchema>;
 export type AppServerReadThreadResponse = z.infer<typeof AppServerReadThreadResponseSchema>;

--- a/packages/codex-protocol/src/ipc.ts
+++ b/packages/codex-protocol/src/ipc.ts
@@ -15,7 +15,7 @@ export const IpcRequestFrameSchema = z
     sourceClientId: NonEmptyStringSchema.optional(),
     version: NonNegativeIntSchema.optional()
   })
-  .strict();
+  .passthrough();
 
 export const IpcResponseFrameSchema = z
   .object({
@@ -27,7 +27,7 @@ export const IpcResponseFrameSchema = z
     result: z.unknown().optional(),
     error: z.unknown().optional()
   })
-  .strict();
+  .passthrough();
 
 export const IpcBroadcastFrameSchema = z
   .object({
@@ -38,7 +38,7 @@ export const IpcBroadcastFrameSchema = z
     targetClientId: NonEmptyStringSchema.optional(),
     version: NonNegativeIntSchema.optional()
   })
-  .strict();
+  .passthrough();
 
 export const IpcClientDiscoveryRequestFrameSchema = z
   .object({
@@ -46,7 +46,7 @@ export const IpcClientDiscoveryRequestFrameSchema = z
     requestId: IpcRequestIdSchema,
     request: IpcRequestFrameSchema
   })
-  .strict();
+  .passthrough();
 
 export const IpcClientDiscoveryResponseFrameSchema = z
   .object({
@@ -56,9 +56,9 @@ export const IpcClientDiscoveryResponseFrameSchema = z
       .object({
         canHandle: z.boolean()
       })
-      .strict()
+      .passthrough()
   })
-  .strict();
+  .passthrough();
 
 export const IpcFrameSchema = z.union([
   IpcRequestFrameSchema,
@@ -68,7 +68,16 @@ export const IpcFrameSchema = z.union([
   IpcClientDiscoveryResponseFrameSchema
 ]);
 
-export const ThreadStreamStateChangedBroadcastSchema = z
+export const ThreadStreamStateChangedBroadcastSchema: z.ZodObject<
+  {
+    type: z.ZodLiteral<"broadcast">;
+    method: z.ZodLiteral<"thread-stream-state-changed">;
+    sourceClientId: typeof NonEmptyStringSchema;
+    params: typeof ThreadStreamStateChangedParamsSchema;
+    version: typeof NonNegativeIntSchema;
+  },
+  "passthrough"
+> = z
   .object({
     type: z.literal("broadcast"),
     method: z.literal("thread-stream-state-changed"),
@@ -76,7 +85,7 @@ export const ThreadStreamStateChangedBroadcastSchema = z
     params: ThreadStreamStateChangedParamsSchema,
     version: NonNegativeIntSchema
   })
-  .strict();
+  .passthrough();
 
 export type IpcFrame = z.infer<typeof IpcFrameSchema>;
 export type IpcRequestFrame = z.infer<typeof IpcRequestFrameSchema>;

--- a/packages/codex-protocol/src/thread.ts
+++ b/packages/codex-protocol/src/thread.ts
@@ -14,14 +14,14 @@ export const CollaborationModeSettingsSchema = z
     reasoning_effort: NullableStringSchema.optional(),
     developer_instructions: z.union([z.string(), z.null()]).optional()
   })
-  .strict();
+  .passthrough();
 
 export const CollaborationModeSchema = z
   .object({
     mode: NonEmptyStringSchema,
     settings: CollaborationModeSettingsSchema
   })
-  .strict();
+  .passthrough();
 
 export const InputTextPartSchema = z
   .object({
@@ -29,7 +29,7 @@ export const InputTextPartSchema = z
     text: z.string(),
     text_elements: z.array(JsonValueSchema).optional()
   })
-  .strict();
+  .passthrough();
 
 export const InputImagePartSchema = z
   .object({
@@ -55,7 +55,7 @@ export const TurnStartParamsSchema = z
     personality: z.union([JsonValueSchema, z.null()]).optional(),
     outputSchema: z.union([JsonValueSchema, z.null()]).optional()
   })
-  .strict();
+  .passthrough();
 
 export const UserMessageContentPartSchema = z
   .object({
@@ -63,7 +63,7 @@ export const UserMessageContentPartSchema = z
     text: z.string(),
     text_elements: z.array(JsonValueSchema).optional()
   })
-  .strict();
+  .passthrough();
 
 export const UserMessageImageContentPartSchema = z
   .object({
@@ -83,7 +83,7 @@ export const UserMessageItemSchema = z
     type: z.literal("userMessage"),
     content: z.array(UserMessagePartSchema)
   })
-  .strict();
+  .passthrough();
 
 export const SteeringUserMessageItemSchema = z
   .object({
@@ -92,7 +92,7 @@ export const SteeringUserMessageItemSchema = z
     content: z.array(UserMessagePartSchema),
     attachments: z.array(JsonValueSchema).optional()
   })
-  .strict();
+  .passthrough();
 
 export const AgentMessageItemSchema = z
   .object({
@@ -100,7 +100,7 @@ export const AgentMessageItemSchema = z
     type: z.literal("agentMessage"),
     text: z.string()
   })
-  .strict();
+  .passthrough();
 
 export const ReasoningItemSchema = z
   .object({
@@ -110,7 +110,7 @@ export const ReasoningItemSchema = z
     content: z.array(JsonValueSchema).optional(),
     text: z.string().optional()
   })
-  .strict();
+  .passthrough();
 
 export const PlanItemSchema = z
   .object({
@@ -118,7 +118,7 @@ export const PlanItemSchema = z
     type: z.literal("plan"),
     text: z.string()
   })
-  .strict();
+  .passthrough();
 
 export const UserInputAnsweredQuestionSchema = z
   .object({
@@ -126,7 +126,7 @@ export const UserInputAnsweredQuestionSchema = z
     header: z.string().optional(),
     question: z.string().optional()
   })
-  .strict();
+  .passthrough();
 
 export const UserInputResponseItemSchema = z
   .object({
@@ -138,7 +138,7 @@ export const UserInputResponseItemSchema = z
     answers: z.record(z.array(z.string())),
     completed: z.boolean()
   })
-  .strict();
+  .passthrough();
 
 export const CommandActionSchema = z
   .object({
@@ -148,7 +148,7 @@ export const CommandActionSchema = z
     path: z.union([z.string(), z.null()]).optional(),
     query: z.string().optional()
   })
-  .strict();
+  .passthrough();
 
 export const CommandExecutionItemSchema = z
   .object({
@@ -163,14 +163,14 @@ export const CommandExecutionItemSchema = z
     exitCode: z.union([z.number().int(), z.null()]).optional(),
     durationMs: z.union([NonNegativeIntSchema, z.null()]).optional()
   })
-  .strict();
+  .passthrough();
 
 export const FileChangeKindSchema = z
   .object({
     type: NonEmptyStringSchema,
     move_path: z.union([z.string(), z.null()]).optional()
   })
-  .strict();
+  .passthrough();
 
 export const FileChangeEntrySchema = z
   .object({
@@ -178,7 +178,7 @@ export const FileChangeEntrySchema = z
     kind: FileChangeKindSchema,
     diff: z.string().optional()
   })
-  .strict();
+  .passthrough();
 
 export const FileChangeItemSchema = z
   .object({
@@ -187,7 +187,7 @@ export const FileChangeItemSchema = z
     changes: z.array(FileChangeEntrySchema),
     status: NonEmptyStringSchema
   })
-  .strict();
+  .passthrough();
 
 export const ContextCompactionItemSchema = z
   .object({
@@ -195,7 +195,7 @@ export const ContextCompactionItemSchema = z
     id: NonEmptyStringSchema,
     completed: z.boolean()
   })
-  .strict();
+  .passthrough();
 
 export const WebSearchActionSchema = z
   .object({
@@ -203,7 +203,7 @@ export const WebSearchActionSchema = z
     query: z.string().optional(),
     queries: z.array(z.string()).optional()
   })
-  .strict();
+  .passthrough();
 
 export const WebSearchItemSchema = z
   .object({
@@ -212,7 +212,7 @@ export const WebSearchItemSchema = z
     query: z.string(),
     action: WebSearchActionSchema
   })
-  .strict();
+  .passthrough();
 
 export const ModelChangedItemSchema = z
   .object({
@@ -221,7 +221,7 @@ export const ModelChangedItemSchema = z
     fromModel: NullableStringSchema.optional(),
     toModel: NullableStringSchema.optional()
   })
-  .strict();
+  .passthrough();
 
 export const TurnItemSchema = z.discriminatedUnion("type", [
   UserMessageItemSchema,
@@ -242,7 +242,7 @@ export const UserInputOptionSchema = z
     label: z.string(),
     description: z.string()
   })
-  .strict();
+  .passthrough();
 
 export const UserInputQuestionSchema = z
   .object({
@@ -253,7 +253,7 @@ export const UserInputQuestionSchema = z
     isSecret: z.boolean(),
     options: z.array(UserInputOptionSchema)
   })
-  .strict();
+  .passthrough();
 
 export const UserInputRequestParamsSchema = z
   .object({
@@ -262,7 +262,7 @@ export const UserInputRequestParamsSchema = z
     itemId: NonEmptyStringSchema,
     questions: z.array(UserInputQuestionSchema)
   })
-  .strict();
+  .passthrough();
 
 export const UserInputRequestSchema = z
   .object({
@@ -271,7 +271,7 @@ export const UserInputRequestSchema = z
     params: UserInputRequestParamsSchema,
     completed: z.boolean().optional()
   })
-  .strict();
+  .passthrough();
 
 export const ThreadTurnSchema = z
   .object({
@@ -320,7 +320,7 @@ export const ThreadStreamPatchSchema = z
     path: z.array(ThreadStreamPatchPathSegmentSchema).min(1),
     value: JsonValueSchema.optional()
   })
-  .strict()
+  .passthrough()
   .superRefine((patch, ctx) => {
     const hasValue = Object.prototype.hasOwnProperty.call(patch, "value");
 
@@ -339,33 +339,52 @@ export const ThreadStreamPatchSchema = z
     }
   });
 
-export const ThreadStreamSnapshotChangeSchema = z
+export const ThreadStreamSnapshotChangeSchema: z.ZodObject<
+  {
+    type: z.ZodLiteral<"snapshot">;
+    conversationState: typeof ThreadConversationStateSchema;
+  },
+  "passthrough"
+> = z
   .object({
     type: z.literal("snapshot"),
     conversationState: ThreadConversationStateSchema
   })
-  .strict();
+  .passthrough();
 
-export const ThreadStreamPatchesChangeSchema = z
+export const ThreadStreamPatchesChangeSchema: z.ZodObject<
+  {
+    type: z.ZodLiteral<"patches">;
+    patches: z.ZodArray<typeof ThreadStreamPatchSchema>;
+  },
+  "passthrough"
+> = z
   .object({
     type: z.literal("patches"),
     patches: z.array(ThreadStreamPatchSchema)
   })
-  .strict();
+  .passthrough();
 
-export const ThreadStreamChangeSchema = z.union([
-  ThreadStreamSnapshotChangeSchema,
-  ThreadStreamPatchesChangeSchema
-]);
+export const ThreadStreamChangeSchema: z.ZodUnion<
+  [typeof ThreadStreamSnapshotChangeSchema, typeof ThreadStreamPatchesChangeSchema]
+> = z.union([ThreadStreamSnapshotChangeSchema, ThreadStreamPatchesChangeSchema]);
 
-export const ThreadStreamStateChangedParamsSchema = z
+export const ThreadStreamStateChangedParamsSchema: z.ZodObject<
+  {
+    conversationId: typeof NonEmptyStringSchema;
+    change: typeof ThreadStreamChangeSchema;
+    version: typeof NonNegativeIntSchema;
+    type: z.ZodLiteral<"thread-stream-state-changed">;
+  },
+  "passthrough"
+> = z
   .object({
     conversationId: NonEmptyStringSchema,
     change: ThreadStreamChangeSchema,
     version: NonNegativeIntSchema,
     type: z.literal("thread-stream-state-changed")
   })
-  .strict();
+  .passthrough();
 
 export type CollaborationMode = z.infer<typeof CollaborationModeSchema>;
 export type TurnStartParams = z.infer<typeof TurnStartParamsSchema>;
@@ -396,13 +415,13 @@ export const UserInputAnswerSchema = z
   .object({
     answers: z.array(z.string().min(1))
   })
-  .strict();
+  .passthrough();
 
 export const UserInputResponsePayloadSchema = z
   .object({
     answers: z.record(UserInputAnswerSchema)
   })
-  .strict();
+  .passthrough();
 
 export type UserInputResponsePayload = z.infer<typeof UserInputResponsePayloadSchema>;
 

--- a/packages/codex-protocol/test/protocol.test.ts
+++ b/packages/codex-protocol/test/protocol.test.ts
@@ -475,13 +475,43 @@ describe("codex-protocol schemas", () => {
           defaultReasoningEffort: "xhigh",
           inputModalities: ["text", "image"],
           supportsPersonality: true,
-          isDefault: true
+          isDefault: true,
+          hidden: true
         }
       ],
       nextCursor: null
     });
 
     expect(parsed.data[0]?.id).toBe("gpt-5.3-codex");
+    expect(parsed.data[0]?.["hidden"]).toBe(true);
+  });
+
+  it("parses unknown top-level keys in app-server model/list response", () => {
+    const parsed = parseAppServerListModelsResponse({
+      data: [
+        {
+          id: "gpt-5.3-codex",
+          model: "gpt-5.3-codex",
+          upgrade: null,
+          displayName: "GPT-5.3 Codex",
+          description: "Latest frontier agentic coding model.",
+          supportedReasoningEfforts: [
+            {
+              reasoningEffort: "medium",
+              description: "Balanced"
+            }
+          ],
+          defaultReasoningEffort: "medium",
+          inputModalities: ["text"],
+          supportsPersonality: true,
+          isDefault: true
+        }
+      ],
+      nextCursor: null,
+      hidden: true
+    });
+
+    expect(parsed["hidden"]).toBe(true);
   });
 
   it("parses app-server thread/read response with subset validation", () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broadly relaxes Zod validation from `strict()` to `passthrough()` across server/web/protocol boundaries, which can hide unexpected payload drift and allow unvalidated data to propagate. Behavior is mostly additive/forward-compatible but affects many request/response validation points.
> 
> **Overview**
> **Relaxes schema strictness across the stack** by switching many Zod schemas from `.strict()` to `.passthrough()` so unknown fields are accepted (and typically preserved) for HTTP request bodies, web API responses, and protocol/app-server/IPC/thread payloads.
> 
> Updates JSON-RPC parsing to accept extra fields and improves `parseJsonRpcIncomingMessage` error reporting by validating response vs notification separately and combining Zod issues when neither matches. Protocol docs and tests are updated to reflect/verify acceptance of unknown keys (e.g., model `hidden` flags and extra top-level response fields).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f229c8ea272128b300a0d02bfb88329be395675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API validation to accept and preserve additional fields in requests and responses, improving compatibility with future versions and external integrations.

* **Tests**
  * Added coverage for hidden flag handling in model list responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->