### PR TITLE
Fix sidebar collapse and Codex project labels

### DIFF
--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -116,6 +116,7 @@ export interface AgentDescriptor {
   connected: boolean;
   capabilities: AgentCapabilities;
   projectDirectories: string[];
+  projectLabels: Record<string, string>;
 }
 
 export interface AgentAdapter {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -185,7 +185,8 @@ const AgentsResponseSchema = z
         enabled: z.boolean(),
         connected: z.boolean(),
         capabilities: AgentCapabilitiesSchema,
-        projectDirectories: z.array(z.string())
+        projectDirectories: z.array(z.string()),
+        projectLabels: z.record(z.string()).default({})
       })
     ),
     defaultAgentId: AgentIdSchema

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -87,6 +87,7 @@ let agentsFixture: {
     connected: boolean;
     capabilities: CapabilityFixture;
     projectDirectories: string[];
+    projectLabels?: Record<string, string>;
   }>;
   defaultAgentId: "codex" | "opencode";
 };
@@ -466,6 +467,47 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: /selected site thread label/i })).toBeNull();
     });
+  });
+
+  it("shows Codex workspace labels for project groups when present", async () => {
+    agentsFixture = {
+      ok: true,
+      agents: [
+        {
+          id: "codex",
+          label: "Codex",
+          enabled: true,
+          connected: true,
+          capabilities: codexCapabilities,
+          projectDirectories: [],
+          projectLabels: {
+            "/tmp/site": "renamed-site"
+          }
+        }
+      ],
+      defaultAgentId: "codex"
+    };
+
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: "thread-site",
+          preview: "thread in renamed project",
+          createdAt: 1700000000,
+          updatedAt: 1700000001,
+          cwd: "/tmp/site",
+          source: "opencode",
+          agentId: "codex"
+        }
+      ],
+      nextCursor: null,
+      pages: 1,
+      truncated: false
+    };
+
+    render(<App />);
+    expect(await screen.findByRole("button", { name: "renamed-site" })).toBeTruthy();
   });
 
   it("updates the picker when remote model changes with same updatedAt and turns", async () => {


### PR DESCRIPTION
## Summary
- fix sidebar collapse so selected project groups can be collapsed
- use Codex workspace root labels for sidebar project names
- add tests covering both behaviors

## Testing
- apps/server: bun run typecheck
- apps/web: bun run typecheck
- apps/web: bun run test -- -t "allows collapsing the selected thread project group|shows Codex workspace labels for project groups when present"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom project labels in project groups, sourced from workspace configuration, providing more meaningful names instead of default folder identifiers.

* **Tests**
  * Added test cases for project group labeling and collapse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->