### PR TITLE
Use Codex workspace labels for project names

### DIFF
--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -116,6 +116,7 @@ export interface AgentDescriptor {
   connected: boolean;
   capabilities: AgentCapabilities;
   projectDirectories: string[];
+  projectLabels: Record<string, string>;
 }
 
 export interface AgentAdapter {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -185,7 +185,8 @@ const AgentsResponseSchema = z
         enabled: z.boolean(),
         connected: z.boolean(),
         capabilities: AgentCapabilitiesSchema,
-        projectDirectories: z.array(z.string())
+        projectDirectories: z.array(z.string()),
+        projectLabels: z.record(z.string()).default({})
       })
     ),
     defaultAgentId: AgentIdSchema

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -87,6 +87,7 @@ let agentsFixture: {
     connected: boolean;
     capabilities: CapabilityFixture;
     projectDirectories: string[];
+    projectLabels?: Record<string, string>;
   }>;
   defaultAgentId: "codex" | "opencode";
 };
@@ -429,6 +430,46 @@ describe("App", () => {
     expect(await screen.findByText("Plan")).toBeTruthy();
   });
 
+  it("shows Codex workspace labels for project groups when present", async () => {
+    agentsFixture = {
+      ok: true,
+      agents: [
+        {
+          id: "codex",
+          label: "Codex",
+          enabled: true,
+          connected: true,
+          capabilities: codexCapabilities,
+          projectDirectories: [],
+          projectLabels: {
+            "/tmp/site": "renamed-site"
+          }
+        }
+      ],
+      defaultAgentId: "codex"
+    };
+
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: "thread-site",
+          preview: "thread in renamed project",
+          createdAt: 1700000000,
+          updatedAt: 1700000001,
+          cwd: "/tmp/site",
+          source: "opencode",
+          agentId: "codex"
+        }
+      ],
+      nextCursor: null,
+      pages: 1,
+      truncated: false
+    };
+
+    render(<App />);
+    expect(await screen.findByRole("button", { name: "renamed-site" })).toBeTruthy();
+  });
   it("updates the picker when remote model changes with same updatedAt and turns", async () => {
     const threadId = "thread-1";
     let modelId = "gpt-old-codex";


### PR DESCRIPTION
<img width="780" height="284" alt="CleanShot 2026-02-22 at 10  41 44@2x" src="https://github.com/user-attachments/assets/7bda220e-a015-43e3-a479-2bceba0e3a6f" />

In Codex desktop app you can rename a project. This respects the renamed project name in Farfield. Also ensured that it works for users that don't have Codex desktop app installed.

Disclaimer: Code written with AI (Codex 5.3).