### PR TITLE
Fix getDefaultServerBaseUrl

### DIFF
--- a/apps/web/src/lib/server-target.ts
+++ b/apps/web/src/lib/server-target.ts
@@ -83,14 +83,13 @@ export function getDefaultServerBaseUrl(): string {
     return `http://127.0.0.1:${String(DEFAULT_SERVER_PORT)}`;
   }
 
-  const protocol = window.location.protocol === "https:" ? "https:" : "http:";
   const hostname = window.location.hostname;
 
   if (isLocalHost(hostname)) {
     return `http://127.0.0.1:${String(DEFAULT_SERVER_PORT)}`;
   }
 
-  return `${protocol}//${hostname}:${String(DEFAULT_SERVER_PORT)}`;
+  return window.location.origin;
 }
 
 export function readStoredServerTarget(): StoredServerTarget | null {


### PR DESCRIPTION
I think there is a breaking change for some setups introduced in https://github.com/achimala/farfield/commit/95379bd26f07c7ddfe2fcb6af1d21b46126850a7

Since this commit, browser defaults to 4311 on non-local ports. If you just run a simple port tunnel via Cloudflare or whatever - this will result in your hosted app trying to connect to `yourdomain.com:4311` for api calls, which is not going to work

I'm not sure how important are those lines for the working of http://farfield.app, but I'm just going to leave it there for now as it's the only way I was able to continue using the app remotely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server base URL detection to use the browser's origin instead of manual construction, ensuring more reliable connection handling in production environments while maintaining existing localhost behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->