### PR TITLE
Fix typo in server package.json (cli.js is not built)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "type": "module",
   "description": "Farfield server for Codex and OpenCode",
-  "bin": "./dist/cli.js",
+  "bin": "./dist/index.js",
   "files": [
     "dist"
   ],
@@ -15,9 +15,9 @@
     "dev": "tsx watch src/index.ts",
     "dev:remote": "HOST=0.0.0.0 PORT=4311 tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bundle": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/cli.js --banner:js='#!/usr/bin/env node' --external:pino --external:zod --external:@opencode-ai/sdk --external:@opencode-ai/sdk/*",
+    "build:bundle": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --banner:js='#!/usr/bin/env node' --external:pino --external:zod --external:@opencode-ai/sdk --external:@opencode-ai/sdk/*",
     "prepack": "bun run build:bundle",
-    "start": "node dist/cli.js",
+    "start": "node dist/index.js",
     "test": "vitest run --passWithNoTests",
     "lint": "tsc -p tsconfig.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit"


### PR DESCRIPTION
since d5428b226735ecb9844889c4549964b0fdb8a0ce it seems that the target was changed to ./dist/cli.js which is not build by default `bun run build` or `bun run dev`

After the patch I was able to run the dev and regular prod setup, but I'm not sure if this breaks or fixes the cli to be honest

Would be great to check to make sure we don't break anything as new as the cli 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CLI entry point and build output configuration in build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->