### PR TITLE
Fix Codex app-server stdout framing

### DIFF
--- a/packages/codex-api/src/app-server-transport.ts
+++ b/packages/codex-api/src/app-server-transport.ts
@@ -65,6 +65,27 @@ function toErrorMessage(error: Error | string): string {
   return error;
 }
 
+function escapeJsonControlCharacter(char: string): string {
+  switch (char) {
+    case "\b":
+      return "\\b";
+    case "\f":
+      return "\\f";
+    case "\n":
+      return "\\n";
+    case "\r":
+      return "\\r";
+    case "\t":
+      return "\\t";
+  }
+
+  const code = char.charCodeAt(0);
+  if (code <= 0x1f) {
+    return `\\u${code.toString(16).padStart(4, "0")}`;
+  }
+  return char;
+}
+
 export class ChildProcessAppServerTransport implements AppServerTransport {
   private readonly executablePath: string;
   private readonly userAgent: string;
@@ -83,6 +104,10 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
   private requestId = 0;
   private initialized = false;
   private initializeInFlight: Promise<void> | null = null;
+  private stdoutFrameBuffer = "";
+  private stdoutFrameDepth = 0;
+  private stdoutFrameInString = false;
+  private stdoutFrameEscaped = false;
 
   public constructor(options: ChildProcessAppServerTransportOptions) {
     this.executablePath = options.executablePath;
@@ -131,6 +156,8 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
       return;
     }
 
+    this.resetStdoutFrameState();
+
     const child = spawn(this.executablePath, ["app-server"], {
       cwd: this.cwd,
       env: {
@@ -143,6 +170,7 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
     });
 
     child.on("exit", (code, signal) => {
+      this.resetStdoutFrameState();
       const reason = `app-server exited (code=${String(code)}, signal=${String(signal)})`;
       this.rejectAll(new AppServerTransportError(reason));
       this.process = null;
@@ -151,6 +179,7 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
     });
 
     child.on("error", (error) => {
+      this.resetStdoutFrameState();
       this.rejectAll(
         new AppServerTransportError(`app-server process error: ${error.message}`)
       );
@@ -159,82 +188,15 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
       this.initializeInFlight = null;
     });
 
-    const lineReader = readline.createInterface({ input: child.stdout });
-    lineReader.on("line", (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        return;
-      }
-
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (text: string) => {
       try {
-        const raw = JSON.parse(trimmed);
-        const message = parseJsonRpcIncomingMessage(raw);
-
-        if (message.kind === "response") {
-          const pending = this.pending.get(message.value.id);
-          if (!pending) {
-            return;
-          }
-
-          this.pending.delete(message.value.id);
-          clearTimeout(pending.timer);
-
-          if (message.value.error) {
-            const responseError = JsonRpcErrorSchema.parse(message.value.error);
-            pending.reject(
-              new AppServerRpcError(
-                responseError.code,
-                responseError.message,
-                responseError.data
-              )
-            );
-            return;
-          }
-
-          pending.resolve(message.value.result);
-          return;
-        }
-
-        if (message.kind === "request") {
-          const parsedRequest = AppServerServerRequestSchema.safeParse(
-            message.value
-          );
-          if (!parsedRequest.success) {
-            void this.sendErrorResponse(
-              message.value.id,
-              -32600,
-              `Unhandled app-server request: ${message.value.method}`
-            ).catch(() => {});
-            return;
-          }
-
-          const request = parsedRequest.data;
-          for (const listener of this.serverRequestListeners) {
-            listener(request);
-          }
-          return;
-        }
-
-        const parsedNotification = AppServerServerNotificationSchema.safeParse(
-          message.value
-        );
-        if (!parsedNotification.success) {
-          return;
-        }
-
-        const notification = parsedNotification.data;
-        for (const listener of this.serverNotificationListeners) {
-          listener(notification);
-        }
+        this.consumeStdoutText(text);
       } catch (error) {
-        const messageText = toErrorMessage(
-          error instanceof Error ? error : String(error)
-        );
         this.rejectAll(
-          new AppServerTransportError(
-            `failed to process app-server message: ${messageText}`
-          )
+          new AppServerTransportError(`invalid app-server stdout: ${String(error)}`)
         );
+        child.kill("SIGTERM");
       }
     });
 
@@ -249,6 +211,149 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
     });
 
     this.process = child;
+  }
+
+  private resetStdoutFrameState(): void {
+    this.stdoutFrameBuffer = "";
+    this.stdoutFrameDepth = 0;
+    this.stdoutFrameInString = false;
+    this.stdoutFrameEscaped = false;
+  }
+
+  private handleIncomingMessage(
+    raw: Parameters<typeof parseJsonRpcIncomingMessage>[0]
+  ): void {
+    const message = parseJsonRpcIncomingMessage(raw);
+
+    if (message.kind === "response") {
+      const pending = this.pending.get(message.value.id);
+      if (!pending) {
+        return;
+      }
+
+      this.pending.delete(message.value.id);
+      clearTimeout(pending.timer);
+
+      if (message.value.error) {
+        const responseError = JsonRpcErrorSchema.parse(message.value.error);
+        pending.reject(
+          new AppServerRpcError(
+            responseError.code,
+            responseError.message,
+            responseError.data
+          )
+        );
+        return;
+      }
+
+      pending.resolve(message.value.result);
+      return;
+    }
+
+    if (message.kind === "request") {
+      const parsedRequest = AppServerServerRequestSchema.safeParse(
+        message.value
+      );
+      if (!parsedRequest.success) {
+        void this.sendErrorResponse(
+          message.value.id,
+          -32600,
+          `Unhandled app-server request: ${message.value.method}`
+        ).catch(() => {});
+        return;
+      }
+
+      const request = parsedRequest.data;
+      for (const listener of this.serverRequestListeners) {
+        listener(request);
+      }
+      return;
+    }
+
+    const parsedNotification = AppServerServerNotificationSchema.safeParse(
+      message.value
+    );
+    if (!parsedNotification.success) {
+      return;
+    }
+
+    const notification = parsedNotification.data;
+    for (const listener of this.serverNotificationListeners) {
+      listener(notification);
+    }
+  }
+
+  private consumeStdoutText(text: string): void {
+    for (const char of text) {
+      if (this.stdoutFrameDepth === 0) {
+        if (/\s/.test(char)) {
+          continue;
+        }
+        if (char !== "{") {
+          throw new AppServerTransportError(
+            `app-server stdout started with unexpected character: ${JSON.stringify(char)}`
+          );
+        }
+        this.resetStdoutFrameState();
+        this.stdoutFrameDepth = 1;
+        this.stdoutFrameBuffer = "{";
+        continue;
+      }
+
+      if (this.stdoutFrameInString) {
+        if (this.stdoutFrameEscaped) {
+          this.stdoutFrameBuffer += escapeJsonControlCharacter(char);
+          this.stdoutFrameEscaped = false;
+          continue;
+        }
+
+        if (char === "\\") {
+          this.stdoutFrameBuffer += char;
+          this.stdoutFrameEscaped = true;
+          continue;
+        }
+
+        if (char === "\"") {
+          this.stdoutFrameBuffer += char;
+          this.stdoutFrameInString = false;
+          continue;
+        }
+
+        this.stdoutFrameBuffer += escapeJsonControlCharacter(char);
+        continue;
+      }
+
+      this.stdoutFrameBuffer += char;
+
+      if (char === "\"") {
+        this.stdoutFrameInString = true;
+        continue;
+      }
+
+      if (char === "{") {
+        this.stdoutFrameDepth += 1;
+        continue;
+      }
+
+      if (char === "}") {
+        this.stdoutFrameDepth -= 1;
+        if (this.stdoutFrameDepth < 0) {
+          throw new AppServerTransportError("app-server stdout produced an unmatched closing brace");
+        }
+        if (this.stdoutFrameDepth === 0) {
+          try {
+            const raw = JSON.parse(this.stdoutFrameBuffer);
+            this.resetStdoutFrameState();
+            this.handleIncomingMessage(raw);
+          } catch (error) {
+            this.resetStdoutFrameState();
+            throw new AppServerTransportError(
+              `failed to process app-server message: ${String(error)}`
+            );
+          }
+        }
+      }
+    }
   }
 
   private rejectAll(error: Error): void {
@@ -407,6 +512,7 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
       return;
     }
 
+    this.resetStdoutFrameState();
     this.process = null;
     this.initialized = false;
     this.initializeInFlight = null;

--- a/packages/codex-api/test/app-server-transport.test.ts
+++ b/packages/codex-api/test/app-server-transport.test.ts
@@ -129,6 +129,27 @@ reader.on("line", (line) => {
   }
 
   if (message.method === "model/list") {
+    if (message.params?.limit === 2) {
+      process.stdout.write(
+        "{\\"id\\":" + message.id + ",\\"result\\":{\\"data\\":[{\\"preview\\":\\"line one" + String.fromCharCode(10) + "line two\\",\\"control\\":\\"a" + String.fromCharCode(0) + "b\\"}]}}\\n"
+      );
+      return;
+    }
+
+    if (message.params?.limit === 3) {
+      const emoji = Buffer.from("😀", "utf8");
+      const payload = Buffer.from(
+        "{\\"id\\":" + message.id + ",\\"result\\":{\\"data\\":[{\\"emoji\\":\\"😀\\"}]}}\\n",
+        "utf8"
+      );
+      const splitAt = payload.indexOf(emoji) + 2;
+      process.stdout.write(payload.subarray(0, splitAt));
+      setTimeout(() => {
+        process.stdout.write(payload.subarray(splitAt));
+      }, 0);
+      return;
+    }
+
     process.stdout.write(JSON.stringify({
       id: message.id,
       result: {
@@ -227,4 +248,61 @@ describe("ChildProcessAppServerTransport", () => {
     },
     15_000,
   );
+
+  it("parses stdout responses with raw control characters inside strings", async () => {
+    const { executablePath, recordsPath } = createFakeAppServer();
+    const stderrLines: string[] = [];
+
+    const transport = new ChildProcessAppServerTransport({
+      executablePath,
+      userAgent: "farfield-test",
+      env: {
+        FAKE_APP_SERVER_RECORDS: recordsPath,
+      },
+      onStderr: (line) => {
+        stderrLines.push(line);
+      },
+    });
+
+    const result = await transport.request("model/list", { limit: 2 });
+    await transport.close();
+
+    expect(result).toEqual({
+      data: [
+        {
+          preview: "line one\nline two",
+          control: "a\u0000b",
+        },
+      ],
+    });
+    expect(stderrLines).toEqual([]);
+  });
+
+  it("parses stdout responses with split multi-byte UTF-8 characters", async () => {
+    const { executablePath, recordsPath } = createFakeAppServer();
+    const stderrLines: string[] = [];
+
+    const transport = new ChildProcessAppServerTransport({
+      executablePath,
+      userAgent: "farfield-test",
+      env: {
+        FAKE_APP_SERVER_RECORDS: recordsPath,
+      },
+      onStderr: (line) => {
+        stderrLines.push(line);
+      },
+    });
+
+    const result = await transport.request("model/list", { limit: 3 });
+    await transport.close();
+
+    expect(result).toEqual({
+      data: [
+        {
+          emoji: "😀",
+        },
+      ],
+    });
+    expect(stderrLines).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- replace line-based Codex app-server stdout parsing with framed JSON assembly
- tolerate literal control characters/newlines inside string values before JSON.parse
- add a regression test covering multi-line stdout payloads

## Problem
Farfield was crashing while loading Codex threads when the app-server returned payloads containing embedded newlines/control characters in string fields. The transport assumed one complete JSON message per readline event, which broke on those payloads and surfaced as UI failures such as `The string did not match the expected pattern`.

## Testing
- bun run --filter @farfield/api test
- bun run --filter @farfield/api typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API server message parsing reliability with enhanced handling of complex data structures and edge cases.
  * Strengthened error detection and recovery mechanisms for communication failures.

* **Tests**
  * Added comprehensive test coverage for server communication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->