### PR TITLE
Add flag to disable rate limit fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ FARFIELD_API_ORIGIN=http://127.0.0.1:4311 bun run start
 
 ### React Compiler and production profiling
 
-Frontend build supports two optional flags:
+Frontend build supports optional flags:
 
 - `REACT_COMPILER=0` disables React Compiler transform (compiler is enabled by default for `vite build`).
 - `REACT_PROFILING=1` uses React profiling build so React DevTools Profiler works in production preview.
+- `DISABLE_RATE_LIMITS=1` disables quota/rate-limit fetching and hides usage badges in the UI. Useful with custom Codex-compatible backends that do not implement account quota endpoints.
 
 Example A/B commands:
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -633,6 +633,7 @@ const ASSUMED_APP_DEFAULT_EFFORT = "medium";
 const AGENT_CACHE_TTL_MS = 30_000;
 const PROVIDER_CATALOG_CACHE_TTL_MS = 20_000;
 const DEBUG_UI_ENABLED = import.meta.env.MODE !== "production";
+const DISABLE_RATE_LIMITS = __FARFIELD_DISABLE_RATE_LIMITS__;
 const MOBILE_SIDEBAR_WIDTH_PX = 256;
 const MOBILE_SWIPE_EDGE_PX = 24;
 const MOBILE_SIDEBAR_TOGGLE_THRESHOLD_PX = 88;
@@ -1688,7 +1689,8 @@ export function App(): React.JSX.Element {
     selectedAgentDescriptor,
     "createThread",
   );
-  const showUsageBadges = activeThreadAgentId === "codex";
+  const showUsageBadges =
+    activeThreadAgentId === "codex" && !DISABLE_RATE_LIMITS;
   const sessionTokenUsage = useMemo(() => {
     const fromConversationState = parseTokenUsageInfo(
       conversationState?.latestTokenUsageInfo,
@@ -1984,7 +1986,9 @@ export function App(): React.JSX.Element {
       : Promise.resolve(cachedAgents.value);
 
     const healthPromise = getHealth();
-    const rateLimitsPromise = getAccountRateLimits().catch(() => null);
+    const rateLimitsPromise = DISABLE_RATE_LIMITS
+      ? Promise.resolve(null)
+      : getAccountRateLimits().catch(() => null);
     const sidebarPromise = listSidebarThreads({
       limit: 80,
       archived: false,

--- a/apps/web/src/pwa.d.ts
+++ b/apps/web/src/pwa.d.ts
@@ -7,3 +7,5 @@ declare module "virtual:pwa-register" {
     onRegisterError?: (error: Error) => void;
   }): (reloadPage?: boolean) => Promise<void>;
 }
+
+declare const __FARFIELD_DISABLE_RATE_LIMITS__: boolean;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,12 +19,17 @@ const FarfieldApiOriginEnvSchema = z.object({
     .enum(["0", "1", "true", "false"])
     .transform((value) => value === "1" || value === "true")
     .optional(),
+  DISABLE_RATE_LIMITS: z
+    .enum(["0", "1", "true", "false"])
+    .transform((value) => value === "1" || value === "true")
+    .optional(),
 });
 const parsedEnv = FarfieldApiOriginEnvSchema.safeParse({
   FARFIELD_API_ORIGIN: process.env["FARFIELD_API_ORIGIN"],
   REACT_COMPILER: process.env["REACT_COMPILER"],
   REACT_PROFILING: process.env["REACT_PROFILING"],
   PWA_ENABLED: process.env["PWA_ENABLED"],
+  DISABLE_RATE_LIMITS: process.env["DISABLE_RATE_LIMITS"],
 });
 if (!parsedEnv.success) {
   const issueDetails = parsedEnv.error.issues
@@ -42,6 +47,7 @@ const apiOrigin =
 const reactCompilerOverride = parsedEnv.data.REACT_COMPILER ?? null;
 const reactProfilingEnabled = parsedEnv.data.REACT_PROFILING ?? false;
 const pwaEnabled = parsedEnv.data.PWA_ENABLED ?? true;
+const disableRateLimits = parsedEnv.data.DISABLE_RATE_LIMITS ?? false;
 
 const resolveAlias: Record<string, string> = {
   "@": path.resolve(__dirname, "./src"),
@@ -58,6 +64,9 @@ export default defineConfig(({ command }) => {
       : reactCompilerOverride;
 
   return {
+    define: {
+      __FARFIELD_DISABLE_RATE_LIMITS__: JSON.stringify(disableRateLimits),
+    },
     plugins: [
       react(
         reactCompilerEnabled


### PR DESCRIPTION
Summary
- add a frontend build-time flag to disable account rate limit/quota fetching
- hide usage/quota badges when the flag is enabled
- document the flag in README

Why
Custom Codex-compatible backends can support chat/completions through a custom base URL but may not implement the account quota endpoint used by Farfield. In that setup the UI still works, but automatic quota polling causes noisy errors.

What changed
- add DISABLE_RATE_LIMITS env parsing in apps/web/vite.config.ts
- expose the value to the frontend as import.meta.env["VITE_DISABLE_RATE_LIMITS"]
- skip getAccountRateLimits() when the flag is enabled
- suppress usage badges when rate-limit fetching is disabled
- document DISABLE_RATE_LIMITS=1 in README

Usage
- dev: DISABLE_RATE_LIMITS=1 bun run dev
- build: DISABLE_RATE_LIMITS=1 bun run build

Validation
- bun install
- bun run prepare:workspace-dist
- bun run --filter @farfield/web typecheck
- bun run --filter @farfield/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional DISABLE_RATE_LIMITS flag to disable quota/rate-limit fetching and hide usage badges in the UI for setups without account quota endpoints.

* **Documentation**
  * Updated build configuration docs to describe the optional flag, accepted values, and its impact on UI and data fetching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->