### PR TITLE
Harden Farfield thread state handling

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "dev:remote": "HOST=0.0.0.0 PORT=4311 tsx watch src/index.ts",
+    "dev:remote": "HOST=0.0.0.0 PORT=4311 tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
     "build:bundle": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --banner:js='#!/usr/bin/env node' --external:pino --external:zod --external:@opencode-ai/sdk --external:@opencode-ai/sdk/*",
     "prepack": "bun run build:bundle",

--- a/apps/server/src/agents/adapters/codex-agent.ts
+++ b/apps/server/src/agents/adapters/codex-agent.ts
@@ -490,11 +490,10 @@ export class CodexAgentAdapter implements AgentAdapter {
         result = await readThreadWithOption(input.includeTurns);
       } catch (error) {
         const typedError = error instanceof Error ? error : null;
-        const shouldTryResume =
-          isThreadNotLoadedAppServerRpcError(typedError) ||
-          (input.includeTurns &&
-            (isThreadNotMaterializedIncludeTurnsAppServerRpcError(typedError) ||
-              isThreadNoRolloutIncludeTurnsAppServerRpcError(typedError)));
+        const shouldTryResume = shouldAttemptArchivedThreadRestoreForReadError(
+          typedError,
+          input.includeTurns,
+        );
         if (!shouldTryResume) {
           throw error;
         }
@@ -520,6 +519,15 @@ export class CodexAgentAdapter implements AgentAdapter {
         }
       }
     } catch (error) {
+      const typedError = error instanceof Error ? error : null;
+      if (
+        !shouldAttemptArchivedThreadRestoreForReadError(
+          typedError,
+          input.includeTurns,
+        )
+      ) {
+        throw error;
+      }
       const restoredThread = await this.restoreArchivedThreadState(
         input.threadId,
         input.includeTurns,
@@ -2605,6 +2613,18 @@ export function isThreadNoRolloutIncludeTurnsAppServerRpcError(
   );
 }
 
+function shouldAttemptArchivedThreadRestoreForReadError(
+  error: Error | null,
+  includeTurns: boolean,
+): boolean {
+  return (
+    isThreadNotLoadedAppServerRpcError(error) ||
+    (includeTurns &&
+      (isThreadNotMaterializedIncludeTurnsAppServerRpcError(error) ||
+        isThreadNoRolloutIncludeTurnsAppServerRpcError(error)))
+  );
+}
+
 export function isIpcNoClientFoundError(error: Error | null): boolean {
   if (!(error instanceof DesktopIpcError)) {
     return false;
@@ -2847,7 +2867,7 @@ async function findRolloutPathInDirectory(
     if (!entry.isFile()) {
       continue;
     }
-    if (!entry.name.endsWith(".jsonl") || !entry.name.includes(threadId)) {
+    if (entry.name !== `${threadId}.jsonl`) {
       continue;
     }
     return path.join(directory, entry.name);

--- a/apps/server/src/agents/adapters/codex-agent.ts
+++ b/apps/server/src/agents/adapters/codex-agent.ts
@@ -78,6 +78,8 @@ const MAX_TRACKED_THREAD_RUNTIME_STATES = 80;
 const MAX_STREAM_EVENTS_PER_THREAD = 120;
 const ARCHIVED_TOOL_ARGUMENT_PREVIEW_MAX_CHARS = 600;
 const ARCHIVED_TOOL_TEXT_PREVIEW_MAX_CHARS = 240;
+const MAX_LOGGED_ARCHIVED_UNKNOWN_PAYLOAD_TYPES = 64;
+const MAX_LOGGED_ARCHIVED_MALFORMED_JSONL_LINES = 512;
 const loggedArchivedUnknownPayloadTypes = new Set<string>();
 const loggedArchivedMalformedJsonlLineKeys = new Set<string>();
 
@@ -919,12 +921,12 @@ export class CodexAgentAdapter implements AgentAdapter {
       };
     }
 
-    const reductionInput = canUseSyntheticSnapshot
+    const reductionInput = canUseSyntheticSnapshot && snapshotState !== null
       ? [
           buildSyntheticSnapshotEvent(
             threadId,
             ownerClientId ?? "farfield",
-            snapshotState!,
+            snapshotState,
           ),
           ...reductionEvents,
         ]
@@ -2130,10 +2132,15 @@ function logArchivedUnknownPayloadType(
   threadId: string,
   payloadType: string,
 ): void {
-  if (loggedArchivedUnknownPayloadTypes.has(payloadType)) {
+  if (
+    !rememberBoundedLoggedArchivedKey(
+      loggedArchivedUnknownPayloadTypes,
+      payloadType,
+      MAX_LOGGED_ARCHIVED_UNKNOWN_PAYLOAD_TYPES,
+    )
+  ) {
     return;
   }
-  loggedArchivedUnknownPayloadTypes.add(payloadType);
   logger.warn(
     {
       threadId,
@@ -2150,10 +2157,15 @@ function logArchivedMalformedJsonlLine(
   truncatedTailCandidate: boolean,
 ): void {
   const key = `${threadId}:${String(lineIndex)}`;
-  if (loggedArchivedMalformedJsonlLineKeys.has(key)) {
+  if (
+    !rememberBoundedLoggedArchivedKey(
+      loggedArchivedMalformedJsonlLineKeys,
+      key,
+      MAX_LOGGED_ARCHIVED_MALFORMED_JSONL_LINES,
+    )
+  ) {
     return;
   }
-  loggedArchivedMalformedJsonlLineKeys.add(key);
   logger.warn(
     {
       threadId,
@@ -2163,6 +2175,25 @@ function logArchivedMalformedJsonlLine(
     },
     "archived-thread-jsonl-line-parse-failed",
   );
+}
+
+function rememberBoundedLoggedArchivedKey(
+  cache: Set<string>,
+  key: string,
+  maxEntries: number,
+): boolean {
+  if (cache.has(key)) {
+    return false;
+  }
+  cache.add(key);
+  if (cache.size <= maxEntries) {
+    return true;
+  }
+  const oldestKey = cache.values().next().value;
+  if (typeof oldestKey === "string") {
+    cache.delete(oldestKey);
+  }
+  return true;
 }
 
 function normalizeArchivedMessageContent(

--- a/apps/server/src/agents/adapters/codex-agent.ts
+++ b/apps/server/src/agents/adapters/codex-agent.ts
@@ -112,7 +112,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     canReadRateLimits: true,
   };
 
-  private readonly appClient: AppServerClient;
+  protected readonly appClient: AppServerClient;
   private readonly ipcClient: DesktopIpcClient;
   private readonly service: CodexMonitorService;
   private readonly onStateChange: (() => void) | null;
@@ -1061,7 +1061,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     this.notifyStateChanged();
   }
 
-  private patchRuntimeState(patch: Partial<CodexAgentRuntimeState>): void {
+  protected patchRuntimeState(patch: Partial<CodexAgentRuntimeState>): void {
     this.setRuntimeState({
       ...this.runtimeState,
       ...patch,
@@ -1222,7 +1222,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     );
   }
 
-  private async restoreArchivedThreadState(
+  protected async restoreArchivedThreadState(
     threadId: string,
     includeTurns: boolean,
   ): Promise<ThreadConversationState | null> {
@@ -1244,14 +1244,19 @@ export class CodexAgentAdapter implements AgentAdapter {
         return null;
       }
 
+      const validated = parseThreadConversationState(restored);
       const normalized = includeTurns
-        ? restored
+        ? validated
         : {
-            ...restored,
+            ...validated,
             turns: [],
           };
-      if (restored.turns.length > 0) {
-        this.setTrackedThreadSnapshot(threadId, restored, "readThreadWithTurns");
+      if (validated.turns.length > 0) {
+        this.setTrackedThreadSnapshot(
+          threadId,
+          validated,
+          "readThreadWithTurns",
+        );
       }
       this.setThreadTitle(threadId, normalized.title);
       this.archivedRestoreHitCount += 1;
@@ -1396,12 +1401,12 @@ export class CodexAgentAdapter implements AgentAdapter {
     this.updateRuntimeHighWaterMarks();
   }
 
-  private setTrackedThreadOwner(threadId: string, ownerClientId: string): void {
+  protected setTrackedThreadOwner(threadId: string, ownerClientId: string): void {
     this.touchTrackedThread(threadId);
     this.threadOwnerById.set(threadId, ownerClientId);
   }
 
-  private setTrackedThreadEvents(threadId: string, events: IpcFrame[]): void {
+  protected setTrackedThreadEvents(threadId: string, events: IpcFrame[]): void {
     this.touchTrackedThread(threadId);
     this.streamEventsByThreadId.set(
       threadId,
@@ -1410,7 +1415,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     this.updateRuntimeHighWaterMarks();
   }
 
-  private setTrackedThreadSnapshot(
+  protected setTrackedThreadSnapshot(
     threadId: string,
     snapshot: ThreadConversationState,
     origin: StreamSnapshotOrigin,
@@ -1420,7 +1425,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     this.streamSnapshotOriginByThreadId.set(threadId, origin);
   }
 
-  private setThreadTitle(
+  protected setThreadTitle(
     threadId: string,
     title: string | null | undefined,
   ): void {
@@ -1535,7 +1540,7 @@ interface ArchivedThreadIndexMetadata {
 interface ArchivedSessionEntry {
   timestamp?: string;
   type?: string;
-  payload?: Record<string, unknown>;
+  payload?: Record<string, ArchivedJsonValue>;
 }
 
 export function buildArchivedThreadConversationStateFromJsonl(
@@ -1874,8 +1879,7 @@ export function buildArchivedThreadConversationStateFromJsonl(
       case "token_count": {
         const payloadInfo = payload["info"];
         if (payloadInfo !== undefined) {
-          latestTokenUsageInfo =
-            payloadInfo as ThreadConversationState["latestTokenUsageInfo"];
+          latestTokenUsageInfo = payloadInfo;
         }
         break;
       }

--- a/apps/server/src/agents/adapters/codex-agent.ts
+++ b/apps/server/src/agents/adapters/codex-agent.ts
@@ -1,3 +1,6 @@
+import { access, readFile, readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   AppServerClient,
   AppServerRpcError,
@@ -71,6 +74,30 @@ export interface CodexAgentOptions {
 }
 
 const ANSI_ESCAPE_REGEX = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+const MAX_TRACKED_THREAD_RUNTIME_STATES = 80;
+const MAX_STREAM_EVENTS_PER_THREAD = 120;
+const ARCHIVED_TOOL_ARGUMENT_PREVIEW_MAX_CHARS = 600;
+const ARCHIVED_TOOL_TEXT_PREVIEW_MAX_CHARS = 240;
+const loggedArchivedUnknownPayloadTypes = new Set<string>();
+const loggedArchivedMalformedJsonlLineKeys = new Set<string>();
+
+type ArchivedJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ArchivedJsonValue[]
+  | { [key: string]: ArchivedJsonValue };
+
+type ArchivedThreadItem = ThreadConversationState["turns"][number]["items"][number];
+type ArchivedDynamicToolCallItem = Extract<
+  ArchivedThreadItem,
+  { type: "dynamicToolCall" }
+>;
+type ArchivedDynamicToolContentItem = NonNullable<
+  ArchivedDynamicToolCallItem["contentItems"]
+>[number];
+type ArchivedTodoListItem = Extract<ArchivedThreadItem, { type: "todoList" }>;
 
 export class CodexAgentAdapter implements AgentAdapter {
   public readonly id = "codex";
@@ -102,9 +129,17 @@ export class CodexAgentAdapter implements AgentAdapter {
     StreamSnapshotOrigin
   >();
   private readonly threadTitleById = new Map<string, string | null>();
+  private readonly trackedThreadIds = new Map<string, true>();
   private readonly ipcFrameListeners = new Set<
     (event: CodexIpcFrameEvent) => void
   >();
+  private maxTrackedThreadCountSeen = 0;
+  private maxTotalBufferedStreamEventCountSeen = 0;
+  private maxBufferedStreamEventsPerThreadSeen = 0;
+  private archivedRestoreHitCount = 0;
+  private archivedRestoreFailureCount = 0;
+  private streamParseFailureCount = 0;
+  private streamReductionFailureCount = 0;
   private lastKnownOwnerClientId: string | null = null;
 
   private runtimeState: CodexAgentRuntimeState = {
@@ -148,7 +183,7 @@ export class CodexAgentAdapter implements AgentAdapter {
       });
 
       if (!state.connected) {
-        this.scheduleIpcReconnect();
+        this.scheduleReconnect();
       } else if (this.reconnectTimer) {
         clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;
@@ -184,10 +219,10 @@ export class CodexAgentAdapter implements AgentAdapter {
       if (frame.type === "broadcast" && threadId) {
         const current = this.streamEventsByThreadId.get(threadId) ?? [];
         current.push(frame);
-        if (current.length > 400) {
-          current.splice(0, current.length - 400);
+        if (current.length > MAX_STREAM_EVENTS_PER_THREAD) {
+          current.splice(0, current.length - MAX_STREAM_EVENTS_PER_THREAD);
         }
-        this.streamEventsByThreadId.set(threadId, current);
+        this.setTrackedThreadEvents(threadId, current);
       }
 
       if (
@@ -210,7 +245,7 @@ export class CodexAgentAdapter implements AgentAdapter {
       }
 
       if (sourceClientId) {
-        this.threadOwnerById.set(conversationId, sourceClientId);
+        this.setTrackedThreadOwner(conversationId, sourceClientId);
       }
 
       try {
@@ -220,8 +255,7 @@ export class CodexAgentAdapter implements AgentAdapter {
         }
 
         const snapshot = parsedBroadcast.params.change.conversationState;
-        this.streamSnapshotByThreadId.set(conversationId, snapshot);
-        this.streamSnapshotOriginByThreadId.set(conversationId, "stream");
+        this.setTrackedThreadSnapshot(conversationId, snapshot, "stream");
         this.setThreadTitle(conversationId, snapshot.title);
       } catch (error) {
         logger.error(
@@ -251,6 +285,43 @@ export class CodexAgentAdapter implements AgentAdapter {
 
   public getThreadOwnerCount(): number {
     return this.threadOwnerById.size;
+  }
+
+  public getTrackedThreadRuntimeCounts(): {
+    trackedThreadCount: number;
+    streamEventThreadCount: number;
+    totalBufferedStreamEventCount: number;
+    streamSnapshotThreadCount: number;
+    threadTitleCount: number;
+    maxTrackedThreadCountSeen: number;
+    maxTotalBufferedStreamEventCountSeen: number;
+    maxBufferedStreamEventsPerThreadSeen: number;
+    archivedRestoreHitCount: number;
+    archivedRestoreFailureCount: number;
+    streamParseFailureCount: number;
+    streamReductionFailureCount: number;
+  } {
+    let totalBufferedStreamEventCount = 0;
+    for (const events of this.streamEventsByThreadId.values()) {
+      totalBufferedStreamEventCount += events.length;
+    }
+
+    return {
+      trackedThreadCount: this.trackedThreadIds.size,
+      streamEventThreadCount: this.streamEventsByThreadId.size,
+      totalBufferedStreamEventCount,
+      streamSnapshotThreadCount: this.streamSnapshotByThreadId.size,
+      threadTitleCount: this.threadTitleById.size,
+      maxTrackedThreadCountSeen: this.maxTrackedThreadCountSeen,
+      maxTotalBufferedStreamEventCountSeen:
+        this.maxTotalBufferedStreamEventCountSeen,
+      maxBufferedStreamEventsPerThreadSeen:
+        this.maxBufferedStreamEventsPerThreadSeen,
+      archivedRestoreHitCount: this.archivedRestoreHitCount,
+      archivedRestoreFailureCount: this.archivedRestoreFailureCount,
+      streamParseFailureCount: this.streamParseFailureCount,
+      streamReductionFailureCount: this.streamReductionFailureCount,
+    };
   }
 
   public isEnabled(): boolean {
@@ -415,53 +486,86 @@ export class CodexAgentAdapter implements AgentAdapter {
 
     let result: Awaited<ReturnType<typeof readThreadWithOption>>;
     try {
-      result = await readThreadWithOption(input.includeTurns);
+      try {
+        result = await readThreadWithOption(input.includeTurns);
+      } catch (error) {
+        const typedError = error instanceof Error ? error : null;
+        const shouldTryResume =
+          isThreadNotLoadedAppServerRpcError(typedError) ||
+          (input.includeTurns &&
+            (isThreadNotMaterializedIncludeTurnsAppServerRpcError(typedError) ||
+              isThreadNoRolloutIncludeTurnsAppServerRpcError(typedError)));
+        if (!shouldTryResume) {
+          throw error;
+        }
+
+        try {
+          await this.resumeThread(input.threadId);
+          result = await readThreadWithOption(input.includeTurns);
+        } catch (resumeRetryError) {
+          const typedResumeRetryError =
+            resumeRetryError instanceof Error ? resumeRetryError : null;
+          const shouldRetryWithoutTurns =
+            input.includeTurns &&
+            (isThreadNotMaterializedIncludeTurnsAppServerRpcError(
+              typedResumeRetryError,
+            ) ||
+              isThreadNoRolloutIncludeTurnsAppServerRpcError(
+                typedResumeRetryError,
+              ));
+          if (!shouldRetryWithoutTurns) {
+            throw resumeRetryError;
+          }
+          result = await readThreadWithOption(false);
+        }
+      }
     } catch (error) {
-      const typedError = error instanceof Error ? error : null;
-      const shouldTryResume =
-        isThreadNotLoadedAppServerRpcError(typedError) ||
-        (input.includeTurns &&
-          (isThreadNotMaterializedIncludeTurnsAppServerRpcError(typedError) ||
-            isThreadNoRolloutIncludeTurnsAppServerRpcError(typedError)));
-      if (!shouldTryResume) {
+      const restoredThread = await this.restoreArchivedThreadState(
+        input.threadId,
+        input.includeTurns,
+      );
+      if (!restoredThread) {
         throw error;
       }
-
-      try {
-        await this.resumeThread(input.threadId);
-        result = await readThreadWithOption(input.includeTurns);
-      } catch (resumeRetryError) {
-        const typedResumeRetryError =
-          resumeRetryError instanceof Error ? resumeRetryError : null;
-        const shouldRetryWithoutTurns =
-          input.includeTurns &&
-          (isThreadNotMaterializedIncludeTurnsAppServerRpcError(
-            typedResumeRetryError,
-          ) ||
-            isThreadNoRolloutIncludeTurnsAppServerRpcError(
-              typedResumeRetryError,
-            ));
-        if (!shouldRetryWithoutTurns) {
-          throw resumeRetryError;
-        }
-        result = await readThreadWithOption(false);
-      }
+      this.patchRuntimeState({
+        lastError: null,
+      });
+      result = {
+        thread: restoredThread,
+      };
     }
-    const parsedThread = parseThreadConversationState(result.thread);
+    let parsedThread: ThreadConversationState;
+    try {
+      parsedThread = parseThreadConversationState(result.thread);
+    } catch (error) {
+      const restoredThread = await this.restoreArchivedThreadState(
+        input.threadId,
+        input.includeTurns,
+      );
+      if (!restoredThread) {
+        throw error;
+      }
+      this.patchRuntimeState({
+        lastError: null,
+      });
+      parsedThread = restoredThread;
+    }
     const existingSnapshot = this.streamSnapshotByThreadId.get(input.threadId);
     const shouldStoreSnapshot =
       input.includeTurns ||
       parsedThread.turns.length > 0 ||
       existingSnapshot === undefined;
     if (shouldStoreSnapshot) {
-      this.streamSnapshotByThreadId.set(input.threadId, parsedThread);
       const snapshotOrigin: StreamSnapshotOrigin =
         input.includeTurns && parsedThread.turns.length > 0
           ? "readThreadWithTurns"
           : "readThread";
-      this.streamSnapshotOriginByThreadId.set(input.threadId, snapshotOrigin);
+      this.setTrackedThreadSnapshot(input.threadId, parsedThread, snapshotOrigin);
     }
     this.setThreadTitle(input.threadId, parsedThread.title);
+    this.patchRuntimeState({
+      lastError: null,
+    });
     return {
       thread: parsedThread,
     };
@@ -489,7 +593,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     })();
 
     if (ownerClientId && this.isIpcReady()) {
-      this.threadOwnerById.set(input.threadId, ownerClientId);
+      this.setTrackedThreadOwner(input.threadId, ownerClientId);
       try {
         await this.service.sendMessage({
           threadId: input.threadId,
@@ -642,18 +746,21 @@ export class CodexAgentAdapter implements AgentAdapter {
         () => this.appClient.readThread(input.threadId, true),
       );
       const parsedThread = parseThreadConversationState(refreshedThread.thread);
-      this.streamSnapshotByThreadId.set(input.threadId, parsedThread);
-      this.streamSnapshotOriginByThreadId.set(input.threadId, "readThreadWithTurns");
       this.setThreadTitle(input.threadId, parsedThread.title);
 
       const currentEvents = this.streamEventsByThreadId.get(input.threadId) ?? [];
       currentEvents.push(
         buildSyntheticSnapshotEvent(input.threadId, ownerClientIdForResult, parsedThread),
       );
-      if (currentEvents.length > 400) {
-        currentEvents.splice(0, currentEvents.length - 400);
+      if (currentEvents.length > MAX_STREAM_EVENTS_PER_THREAD) {
+        currentEvents.splice(0, currentEvents.length - MAX_STREAM_EVENTS_PER_THREAD);
       }
-      this.streamEventsByThreadId.set(input.threadId, currentEvents);
+      this.setTrackedThreadSnapshot(
+        input.threadId,
+        parsedThread,
+        "readThreadWithTurns",
+      );
+      this.setTrackedThreadEvents(input.threadId, currentEvents);
 
       return {
         ownerClientId: ownerClientIdForResult,
@@ -668,7 +775,7 @@ export class CodexAgentAdapter implements AgentAdapter {
       input.ownerClientId,
       this.lastKnownOwnerClientId ?? undefined,
     );
-    this.threadOwnerById.set(input.threadId, ownerClientId);
+    this.setTrackedThreadOwner(input.threadId, ownerClientId);
 
     const pendingIpcRequest = await this.resolvePendingIpcRequest(
       input.threadId,
@@ -730,12 +837,20 @@ export class CodexAgentAdapter implements AgentAdapter {
   }
 
   public async readLiveState(threadId: string): Promise<AgentThreadLiveState> {
-    const snapshotState = this.streamSnapshotByThreadId.get(threadId) ?? null;
-    const snapshotOrigin =
+    this.touchTrackedThread(threadId);
+    let snapshotState = this.streamSnapshotByThreadId.get(threadId) ?? null;
+    let snapshotOrigin =
       this.streamSnapshotOriginByThreadId.get(threadId) ?? null;
     const ownerClientId =
       this.threadOwnerById.get(threadId) ?? this.lastKnownOwnerClientId ?? null;
     const rawEvents = this.streamEventsByThreadId.get(threadId) ?? [];
+    if (rawEvents.length === 0 && snapshotState === null) {
+      const restoredState = await this.restoreArchivedThreadState(threadId, true);
+      if (restoredState) {
+        snapshotState = restoredState;
+        snapshotOrigin = "readThreadWithTurns";
+      }
+    }
     if (rawEvents.length === 0) {
       return {
         ownerClientId,
@@ -744,37 +859,32 @@ export class CodexAgentAdapter implements AgentAdapter {
       };
     }
 
-    const events: ReturnType<typeof parseThreadStreamStateChangedBroadcast>[] =
-      [];
-
-    for (let eventIndex = 0; eventIndex < rawEvents.length; eventIndex += 1) {
-      const event = rawEvents[eventIndex];
-      try {
-        events.push(parseThreadStreamStateChangedBroadcast(event));
-      } catch (error) {
-        logger.error(
-          {
-            threadId,
-            eventIndex,
-            error: toErrorMessage(error),
-            ...(error instanceof ProtocolValidationError
-              ? { issues: error.issues }
-              : {}),
-          },
-          "thread-stream-event-parse-failed",
-        );
-        return {
-          ownerClientId,
-          conversationState: snapshotState,
-          liveStateError: {
-            kind: "parseFailed",
-            message: toErrorMessage(error),
-            eventIndex,
-            patchIndex: null,
-          },
-        };
-      }
+    const collectedEvents = collectThreadStreamStateChangedEvents(rawEvents);
+    if (collectedEvents.parseError) {
+      this.streamParseFailureCount += 1;
+      logger.error(
+        {
+          threadId,
+          eventIndex: collectedEvents.parseError.eventIndex,
+          error: collectedEvents.parseError.message,
+          ...(collectedEvents.parseError.issues
+            ? { issues: collectedEvents.parseError.issues }
+            : {}),
+        },
+        "thread-stream-event-parse-failed",
+      );
+      return {
+        ownerClientId,
+        conversationState: snapshotState,
+        liveStateError: {
+          kind: "parseFailed",
+          message: collectedEvents.parseError.message,
+          eventIndex: collectedEvents.parseError.eventIndex,
+          patchIndex: null,
+        },
+      };
     }
+    const events = collectedEvents.events;
 
     if (events.length === 0) {
       return {
@@ -806,7 +916,7 @@ export class CodexAgentAdapter implements AgentAdapter {
           buildSyntheticSnapshotEvent(
             threadId,
             ownerClientId ?? "farfield",
-            snapshotState,
+            snapshotState!,
           ),
           ...reductionEvents,
         ]
@@ -820,6 +930,7 @@ export class CodexAgentAdapter implements AgentAdapter {
         liveStateError: null,
       };
     } catch (error) {
+      this.streamReductionFailureCount += 1;
       const reductionErrorDetails =
         error instanceof ThreadStreamReductionError ? error.details : null;
       const eventIndex = reductionErrorDetails?.eventIndex ?? null;
@@ -853,6 +964,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     threadId: string,
     limit: number,
   ): Promise<AgentThreadStreamEvents> {
+    this.touchTrackedThread(threadId);
     return {
       ownerClientId:
         this.threadOwnerById.get(threadId) ??
@@ -970,7 +1082,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     }
   }
 
-  private scheduleIpcReconnect(): void {
+  private scheduleReconnect(): void {
     if (
       this.reconnectTimer ||
       !this.runtimeState.codexAvailable ||
@@ -994,6 +1106,9 @@ export class CodexAgentAdapter implements AgentAdapter {
       });
       return result;
     } catch (error) {
+      if (error instanceof AppServerTransportError) {
+        this.scheduleReconnect();
+      }
       this.patchRuntimeState({
         appReady: !(error instanceof AppServerTransportError),
         lastError: toErrorMessage(error),
@@ -1027,6 +1142,8 @@ export class CodexAgentAdapter implements AgentAdapter {
             lastError: message,
           });
           logger.warn({ error: message }, "codex-not-found");
+        } else {
+          this.scheduleReconnect();
         }
       }
 
@@ -1053,7 +1170,7 @@ export class CodexAgentAdapter implements AgentAdapter {
           ipcConnected: this.ipcClient.isConnected(),
           lastError: toErrorMessage(error),
         });
-        this.scheduleIpcReconnect();
+        this.scheduleReconnect();
       } finally {
         this.bootstrapInFlight = null;
       }
@@ -1103,6 +1220,54 @@ export class CodexAgentAdapter implements AgentAdapter {
         persistExtendedHistory: true,
       }),
     );
+  }
+
+  private async restoreArchivedThreadState(
+    threadId: string,
+    includeTurns: boolean,
+  ): Promise<ThreadConversationState | null> {
+    const rolloutPath = await findArchivedRolloutPath(threadId);
+    if (!rolloutPath) {
+      return null;
+    }
+
+    try {
+      const content = await readFile(rolloutPath, "utf8");
+      const metadata = await readThreadIndexMetadata(threadId);
+      const restored = buildArchivedThreadConversationStateFromJsonl(
+        content,
+        threadId,
+        metadata,
+      );
+      if (!restored) {
+        this.archivedRestoreFailureCount += 1;
+        return null;
+      }
+
+      const normalized = includeTurns
+        ? restored
+        : {
+            ...restored,
+            turns: [],
+          };
+      if (restored.turns.length > 0) {
+        this.setTrackedThreadSnapshot(threadId, restored, "readThreadWithTurns");
+      }
+      this.setThreadTitle(threadId, normalized.title);
+      this.archivedRestoreHitCount += 1;
+      return normalized;
+    } catch (error) {
+      this.archivedRestoreFailureCount += 1;
+      logger.warn(
+        {
+          threadId,
+          rolloutPath,
+          error: toErrorMessage(error),
+        },
+        "archived-thread-restore-failed",
+      );
+      return null;
+    }
   }
 
   private async isThreadLoaded(threadId: string): Promise<boolean> {
@@ -1207,10 +1372,59 @@ export class CodexAgentAdapter implements AgentAdapter {
     return snapshot.title;
   }
 
+  private touchTrackedThread(threadId: string): void {
+    const normalized = threadId.trim();
+    if (normalized.length === 0) {
+      return;
+    }
+    if (this.trackedThreadIds.has(normalized)) {
+      this.trackedThreadIds.delete(normalized);
+    }
+    this.trackedThreadIds.set(normalized, true);
+    while (this.trackedThreadIds.size > MAX_TRACKED_THREAD_RUNTIME_STATES) {
+      const oldestThreadId = this.trackedThreadIds.keys().next().value;
+      if (typeof oldestThreadId !== "string") {
+        return;
+      }
+      this.trackedThreadIds.delete(oldestThreadId);
+      this.threadOwnerById.delete(oldestThreadId);
+      this.streamEventsByThreadId.delete(oldestThreadId);
+      this.streamSnapshotByThreadId.delete(oldestThreadId);
+      this.streamSnapshotOriginByThreadId.delete(oldestThreadId);
+      this.threadTitleById.delete(oldestThreadId);
+    }
+    this.updateRuntimeHighWaterMarks();
+  }
+
+  private setTrackedThreadOwner(threadId: string, ownerClientId: string): void {
+    this.touchTrackedThread(threadId);
+    this.threadOwnerById.set(threadId, ownerClientId);
+  }
+
+  private setTrackedThreadEvents(threadId: string, events: IpcFrame[]): void {
+    this.touchTrackedThread(threadId);
+    this.streamEventsByThreadId.set(
+      threadId,
+      events.slice(-MAX_STREAM_EVENTS_PER_THREAD),
+    );
+    this.updateRuntimeHighWaterMarks();
+  }
+
+  private setTrackedThreadSnapshot(
+    threadId: string,
+    snapshot: ThreadConversationState,
+    origin: StreamSnapshotOrigin,
+  ): void {
+    this.touchTrackedThread(threadId);
+    this.streamSnapshotByThreadId.set(threadId, snapshot);
+    this.streamSnapshotOriginByThreadId.set(threadId, origin);
+  }
+
   private setThreadTitle(
     threadId: string,
     title: string | null | undefined,
   ): void {
+    this.touchTrackedThread(threadId);
     if (title === undefined) {
       this.threadTitleById.delete(threadId);
       return;
@@ -1229,6 +1443,32 @@ export class CodexAgentAdapter implements AgentAdapter {
 
     this.threadTitleById.set(threadId, title);
   }
+
+  private updateRuntimeHighWaterMarks(): void {
+    this.maxTrackedThreadCountSeen = Math.max(
+      this.maxTrackedThreadCountSeen,
+      this.trackedThreadIds.size,
+    );
+
+    let totalBufferedStreamEventCount = 0;
+    let maxBufferedStreamEventsPerThread = 0;
+    for (const events of this.streamEventsByThreadId.values()) {
+      totalBufferedStreamEventCount += events.length;
+      maxBufferedStreamEventsPerThread = Math.max(
+        maxBufferedStreamEventsPerThread,
+        events.length,
+      );
+    }
+
+    this.maxTotalBufferedStreamEventCountSeen = Math.max(
+      this.maxTotalBufferedStreamEventCountSeen,
+      totalBufferedStreamEventCount,
+    );
+    this.maxBufferedStreamEventsPerThreadSeen = Math.max(
+      this.maxBufferedStreamEventsPerThreadSeen,
+      maxBufferedStreamEventsPerThread,
+    );
+  }
 }
 
 function toErrorMessage(error: Error | string | unknown): string {
@@ -1239,6 +1479,1070 @@ function toErrorMessage(error: Error | string | unknown): string {
     return error;
   }
   return String(error);
+}
+
+export function collectThreadStreamStateChangedEvents(rawEvents: IpcFrame[]): {
+  events: ThreadStreamStateChangedBroadcast[];
+  parseError:
+    | {
+        eventIndex: number;
+        message: string;
+        issues?: ProtocolValidationError["issues"];
+      }
+    | null;
+} {
+  const events: ThreadStreamStateChangedBroadcast[] = [];
+
+  for (let eventIndex = 0; eventIndex < rawEvents.length; eventIndex += 1) {
+    const event = rawEvents[eventIndex];
+    if (!event) {
+      continue;
+    }
+    if (
+      event.type !== "broadcast" ||
+      event.method !== "thread-stream-state-changed"
+    ) {
+      continue;
+    }
+
+    try {
+      events.push(parseThreadStreamStateChangedBroadcast(event));
+    } catch (error) {
+      return {
+        events,
+        parseError: {
+          eventIndex,
+          message: toErrorMessage(error),
+          ...(error instanceof ProtocolValidationError
+            ? { issues: error.issues }
+            : {}),
+        },
+      };
+    }
+  }
+
+  return {
+    events,
+    parseError: null,
+  };
+}
+
+interface ArchivedThreadIndexMetadata {
+  title: string | null;
+  updatedAt: number | null;
+}
+
+interface ArchivedSessionEntry {
+  timestamp?: string;
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+export function buildArchivedThreadConversationStateFromJsonl(
+  content: string,
+  threadId: string,
+  metadata?: ArchivedThreadIndexMetadata | null,
+): ThreadConversationState | null {
+  const entries: ArchivedSessionEntry[] = [];
+  const lines = content.split(/\r?\n/);
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    const trimmed = line?.trim() ?? "";
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    try {
+      entries.push(JSON.parse(trimmed) as ArchivedSessionEntry);
+    } catch (error) {
+      logArchivedMalformedJsonlLine(
+        threadId,
+        lineIndex,
+        toErrorMessage(error),
+        lineIndex === lines.length - 1,
+      );
+    }
+  }
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  let itemCounter = 0;
+  let createdAt = Number.POSITIVE_INFINITY;
+  let updatedAt = 0;
+  let cwd: string | undefined;
+  let source: string | undefined;
+  let title = metadata?.title ?? null;
+  let latestModel: string | null = null;
+  let latestReasoningEffort: string | null = null;
+  let latestTokenUsageInfo: ThreadConversationState["latestTokenUsageInfo"];
+  let currentTurn: ThreadConversationState["turns"][number] | null = null;
+  const turns: ThreadConversationState["turns"] = [];
+  const archivedToolCallsById = new Map<string, ArchivedDynamicToolCallItem>();
+
+  const nextItemId = () => `archived-item-${String(++itemCounter)}`;
+
+  const ensureTurn = () => {
+    if (currentTurn) {
+      return currentTurn;
+    }
+
+    currentTurn = {
+      id: `archived-turn-${String(turns.length + 1)}`,
+      status: "completed",
+      items: [],
+    };
+    turns.push(currentTurn);
+    return currentTurn;
+  };
+
+  const finalizeTurn = (
+    turnId: string | null | undefined,
+    completedAtMs: number | null,
+  ) => {
+    if (!currentTurn) {
+      return;
+    }
+    if (turnId && !currentTurn.turnId) {
+      currentTurn.turnId = turnId;
+    }
+    currentTurn.status = "completed";
+    if (
+      completedAtMs !== null &&
+      currentTurn.finalAssistantStartedAtMs === undefined
+    ) {
+      currentTurn.finalAssistantStartedAtMs = completedAtMs;
+    }
+    currentTurn = null;
+  };
+
+  const ensureArchivedToolCall = (
+    callId: string,
+    tool: unknown,
+    argumentsValue: unknown,
+    status: ArchivedDynamicToolCallItem["status"] = "inProgress",
+  ): ArchivedDynamicToolCallItem => {
+    const normalizedTool = normalizeArchivedToolName(tool);
+    const existing = archivedToolCallsById.get(callId);
+    if (existing) {
+      if (existing.tool === "legacyTool" && normalizedTool !== "legacyTool") {
+        existing.tool = normalizedTool;
+      }
+      if (argumentsValue !== undefined) {
+        existing.arguments = normalizeArchivedToolArguments(argumentsValue);
+      }
+      if (status !== "inProgress" || existing.status === "inProgress") {
+        existing.status = status;
+      }
+      return existing;
+    }
+
+    const turn = ensureTurn();
+    const item: ArchivedDynamicToolCallItem = {
+      id: nextItemId(),
+      type: "dynamicToolCall",
+      tool: normalizedTool,
+      arguments: normalizeArchivedToolArguments(argumentsValue),
+      status,
+    };
+    turn.items.push(item);
+    archivedToolCallsById.set(callId, item);
+    return item;
+  };
+
+  for (const entry of entries) {
+    const timestampSeconds = parseTimestampToUnixSeconds(entry.timestamp);
+    if (timestampSeconds !== null) {
+      createdAt = Math.min(createdAt, timestampSeconds);
+      updatedAt = Math.max(updatedAt, timestampSeconds);
+    }
+
+    const payload = entry.payload;
+    const payloadType = payload?.["type"];
+    if (!payload || typeof payloadType !== "string") {
+      continue;
+    }
+
+    switch (payloadType) {
+      case "session_meta": {
+        const payloadCwd = payload["cwd"];
+        if (typeof payloadCwd === "string" && payloadCwd.trim().length > 0) {
+          cwd = payloadCwd;
+        }
+        const payloadSource = payload["source"];
+        if (
+          typeof payloadSource === "string" &&
+          payloadSource.trim().length > 0
+        ) {
+          source = payloadSource;
+        }
+        title = readArchivedString(payload, [
+          "thread_name",
+          "threadName",
+          "title",
+          "name",
+        ]) ?? title;
+        latestModel =
+          readArchivedString(payload, ["model", "latestModel", "model_name"]) ??
+          latestModel;
+        latestReasoningEffort =
+          readArchivedString(payload, [
+            "reasoning_effort",
+            "reasoningEffort",
+            "effort",
+          ]) ?? latestReasoningEffort;
+        break;
+      }
+
+      case "task_started": {
+        if (currentTurn) {
+          finalizeTurn(null, null);
+        }
+        const payloadTurnId = payload["turn_id"];
+        currentTurn = {
+          id: `archived-turn-${String(turns.length + 1)}`,
+          ...(typeof payloadTurnId === "string" && payloadTurnId.trim()
+            ? { turnId: payloadTurnId }
+            : {}),
+          status: "inProgress",
+          ...(timestampSeconds !== null
+            ? { turnStartedAtMs: timestampSeconds * 1000 }
+            : {}),
+          items: [],
+        };
+        turns.push(currentTurn);
+        latestModel =
+          readArchivedString(payload, ["model", "latestModel", "model_name"]) ??
+          latestModel;
+        latestReasoningEffort =
+          readArchivedString(payload, [
+            "reasoning_effort",
+            "reasoningEffort",
+            "effort",
+          ]) ?? latestReasoningEffort;
+        break;
+      }
+
+      case "user_message": {
+        const turn = ensureTurn();
+        const contentItems: ThreadConversationState["turns"][number]["items"][number] &
+          { type: "userMessage" } = {
+          id: nextItemId(),
+          type: "userMessage",
+          content: [],
+        };
+
+        const payloadMessage = payload["message"];
+        if (typeof payloadMessage === "string" && payloadMessage.length > 0) {
+          contentItems.content.push({
+            type: "text",
+            text: payloadMessage,
+          });
+        }
+
+        const payloadImages = payload["images"];
+        if (Array.isArray(payloadImages)) {
+          for (const image of payloadImages) {
+            if (typeof image === "string" && image.trim().length > 0) {
+              contentItems.content.push({
+                type: "image",
+                url: image,
+              });
+            }
+          }
+        }
+
+        if (contentItems.content.length > 0) {
+          turn.items.push(contentItems);
+        }
+        break;
+      }
+
+      case "message": {
+        const role = readArchivedString(payload, ["role"]);
+        if (!role) {
+          break;
+        }
+
+        if (role === "assistant") {
+          const text = normalizeArchivedAssistantMessageText(payload["content"]);
+          if (!text) {
+            break;
+          }
+          const turn = ensureTurn();
+          const payloadPhase = payload["phase"];
+          turn.items.push({
+            id: nextItemId(),
+            type: "agentMessage",
+            text,
+            ...(typeof payloadPhase === "string" ? { phase: payloadPhase } : {}),
+          });
+          break;
+        }
+
+        const content = normalizeArchivedMessageContent(payload["content"]);
+        if (content.length === 0) {
+          break;
+        }
+
+        const turn = ensureTurn();
+        if (role === "developer" || role === "system") {
+          turn.items.push({
+            id: nextItemId(),
+            type: "steeringUserMessage",
+            content,
+          });
+          break;
+        }
+
+        turn.items.push({
+          id: nextItemId(),
+          type: "userMessage",
+          content,
+        });
+        break;
+      }
+
+      case "agent_message": {
+        const payloadMessage = payload["message"];
+        if (typeof payloadMessage !== "string" || payloadMessage.length === 0) {
+          break;
+        }
+        const turn = ensureTurn();
+        const payloadPhase = payload["phase"];
+        turn.items.push({
+          id: nextItemId(),
+          type: "agentMessage",
+          text: payloadMessage,
+          ...(typeof payloadPhase === "string" ? { phase: payloadPhase } : {}),
+        });
+        break;
+      }
+
+      case "reasoning": {
+        const payloadSummary = payload["summary"];
+        const summary = Array.isArray(payloadSummary)
+          ? payloadSummary.filter(
+              (entry): entry is string => typeof entry === "string",
+            )
+          : [];
+        if (summary.length === 0) {
+          break;
+        }
+        const turn = ensureTurn();
+        turn.items.push({
+          id: nextItemId(),
+          type: "reasoning",
+          summary,
+        });
+        break;
+      }
+
+      case "agent_reasoning": {
+        const payloadText = readArchivedString(payload, ["text", "message"]);
+        const turn = ensureTurn();
+        const payloadSummary = payload["summary"];
+        const summary = Array.isArray(payloadSummary)
+          ? payloadSummary.filter(
+              (entry): entry is string => typeof entry === "string",
+            )
+          : [];
+        if (summary.length === 0 && !payloadText) {
+          break;
+        }
+        turn.items.push({
+          id: nextItemId(),
+          type: "reasoning",
+          ...(summary.length > 0 ? { summary } : {}),
+          ...(payloadText ? { text: payloadText } : {}),
+        });
+        break;
+      }
+
+      case "context_compacted":
+      case "compacted": {
+        const turn = ensureTurn();
+        turn.items.push({
+          id: nextItemId(),
+          type: "contextCompaction",
+          completed: true,
+        });
+        break;
+      }
+
+      case "token_count": {
+        const payloadInfo = payload["info"];
+        if (payloadInfo !== undefined) {
+          latestTokenUsageInfo =
+            payloadInfo as ThreadConversationState["latestTokenUsageInfo"];
+        }
+        break;
+      }
+
+      case "web_search_call": {
+        const callId =
+          readArchivedString(payload, ["call_id", "callId"]) ??
+          `archived-web-search-${entry.timestamp ?? String(itemCounter + 1)}`;
+        const action = payload["action"];
+        const item = ensureArchivedToolCall(
+          callId,
+          "web_search",
+          action ?? payload,
+          normalizeArchivedToolStatus(payload["status"], null, "completed"),
+        );
+        const contentItems = normalizeArchivedToolContentItems(
+          normalizeArchivedWebSearchContent(action),
+        );
+        if (contentItems) {
+          item.contentItems = contentItems;
+        }
+        break;
+      }
+
+      case "function_call": {
+        const callId = readArchivedString(payload, ["call_id", "callId"]);
+        if (!callId) {
+          break;
+        }
+        ensureArchivedToolCall(callId, payload["name"], payload["arguments"]);
+        break;
+      }
+
+      case "function_call_output": {
+        const callId = readArchivedString(payload, ["call_id", "callId"]);
+        if (!callId) {
+          break;
+        }
+        const output = payload["output"];
+        const success = normalizeArchivedToolSuccess(output, true);
+        const item = ensureArchivedToolCall(
+          callId,
+          payload["name"],
+          undefined,
+          normalizeArchivedToolStatus(undefined, success, "completed"),
+        );
+        const contentItems = normalizeArchivedToolContentItems(output);
+        if (contentItems) {
+          item.contentItems = contentItems;
+        }
+        if (success !== null) {
+          item.success = success;
+        }
+        break;
+      }
+
+      case "custom_tool_call": {
+        const callId = readArchivedString(payload, ["call_id", "callId"]);
+        if (!callId) {
+          break;
+        }
+        ensureArchivedToolCall(
+          callId,
+          payload["name"],
+          payload["input"],
+          normalizeArchivedToolStatus(payload["status"], null, "inProgress"),
+        );
+        break;
+      }
+
+      case "custom_tool_call_output": {
+        const callId = readArchivedString(payload, ["call_id", "callId"]);
+        if (!callId) {
+          break;
+        }
+        const output = payload["output"];
+        const success = normalizeArchivedToolSuccess(output, true);
+        const item = ensureArchivedToolCall(
+          callId,
+          payload["name"],
+          undefined,
+          normalizeArchivedToolStatus(undefined, success, "completed"),
+        );
+        const contentItems = normalizeArchivedToolContentItems(output);
+        if (contentItems) {
+          item.contentItems = contentItems;
+        }
+        if (success !== null) {
+          item.success = success;
+        }
+        break;
+      }
+
+      case "dynamic_tool_call_request": {
+        const callId = readArchivedString(payload, ["call_id", "callId"]);
+        if (!callId) {
+          break;
+        }
+        ensureArchivedToolCall(callId, payload["tool"], payload["arguments"]);
+        break;
+      }
+
+      case "dynamic_tool_call_response": {
+        const callId = readArchivedString(payload, ["call_id", "callId"]);
+        if (!callId) {
+          break;
+        }
+        const errorText = readArchivedString(payload, ["error"]);
+        const success = normalizeArchivedToolSuccess(
+          payload["success"],
+          errorText ? false : null,
+        );
+        const item = ensureArchivedToolCall(
+          callId,
+          payload["tool"],
+          payload["arguments"],
+          normalizeArchivedToolStatus(payload["status"], success, "completed"),
+        );
+        const contentItems =
+          normalizeArchivedToolContentItems(payload["content_items"]) ??
+          (errorText
+            ? [
+                {
+                  type: "inputText",
+                  text: truncateArchivedTextPreview(
+                    errorText,
+                    ARCHIVED_TOOL_TEXT_PREVIEW_MAX_CHARS,
+                  ),
+                },
+              ]
+            : null);
+        if (contentItems) {
+          item.contentItems = contentItems;
+        }
+        if (success !== null) {
+          item.success = success;
+        }
+        const durationMs = parseArchivedDurationToMs(payload["duration"]);
+        if (durationMs !== null) {
+          item.durationMs = durationMs;
+        }
+        break;
+      }
+
+      case "todo_list":
+      case "todo-list":
+      case "todoList":
+      case "plan_update": {
+        const plan = normalizeArchivedTodoPlan(payload["plan"]);
+        if (plan.length === 0) {
+          break;
+        }
+        const explanation = payload["explanation"];
+        const turn = ensureTurn();
+        turn.items.push({
+          id: nextItemId(),
+          type: "todoList",
+          ...(typeof explanation === "string" || explanation === null
+            ? { explanation }
+            : {}),
+          plan,
+        });
+        break;
+      }
+
+      case "thread_name_updated": {
+        title =
+          readArchivedString(payload, [
+            "thread_name",
+            "threadName",
+            "title",
+            "name",
+          ]) ?? title;
+        break;
+      }
+
+      case "task_complete": {
+        const payloadTurnId = payload["turn_id"];
+        finalizeTurn(
+          typeof payloadTurnId === "string" ? payloadTurnId : null,
+          timestampSeconds !== null ? timestampSeconds * 1000 : null,
+        );
+        break;
+      }
+
+      default:
+        logArchivedUnknownPayloadType(threadId, payloadType);
+        break;
+    }
+  }
+
+  if (currentTurn) {
+    currentTurn.status = "completed";
+    currentTurn = null;
+  }
+
+  if (turns.length === 0 && latestTokenUsageInfo === undefined) {
+    return null;
+  }
+
+  const normalizedCreatedAt = Number.isFinite(createdAt)
+    ? createdAt
+    : metadata?.updatedAt ?? 0;
+  const normalizedUpdatedAt =
+    updatedAt > 0 ? updatedAt : metadata?.updatedAt ?? normalizedCreatedAt;
+
+  return {
+    id: threadId,
+    turns,
+    requests: [],
+    ...(normalizedCreatedAt > 0 ? { createdAt: normalizedCreatedAt } : {}),
+    ...(normalizedUpdatedAt > 0 ? { updatedAt: normalizedUpdatedAt } : {}),
+    ...(title !== undefined ? { title } : {}),
+    latestModel,
+    latestReasoningEffort,
+    ...(cwd ? { cwd } : {}),
+    ...(source ? { source } : {}),
+    ...(latestTokenUsageInfo !== undefined ? { latestTokenUsageInfo } : {}),
+  };
+}
+
+function readArchivedString(
+  payload: Record<string, unknown>,
+  keys: string[],
+): string | null {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const normalized = value.trim();
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function logArchivedUnknownPayloadType(
+  threadId: string,
+  payloadType: string,
+): void {
+  if (loggedArchivedUnknownPayloadTypes.has(payloadType)) {
+    return;
+  }
+  loggedArchivedUnknownPayloadTypes.add(payloadType);
+  logger.warn(
+    {
+      threadId,
+      payloadType,
+    },
+    "archived-thread-unknown-payload-type",
+  );
+}
+
+function logArchivedMalformedJsonlLine(
+  threadId: string,
+  lineIndex: number,
+  error: string,
+  truncatedTailCandidate: boolean,
+): void {
+  const key = `${threadId}:${String(lineIndex)}`;
+  if (loggedArchivedMalformedJsonlLineKeys.has(key)) {
+    return;
+  }
+  loggedArchivedMalformedJsonlLineKeys.add(key);
+  logger.warn(
+    {
+      threadId,
+      lineIndex,
+      error,
+      truncatedTailCandidate,
+    },
+    "archived-thread-jsonl-line-parse-failed",
+  );
+}
+
+function normalizeArchivedMessageContent(
+  value: unknown,
+): Array<{ type: "text"; text: string } | { type: "image"; url: string }> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap<{ type: "text"; text: string } | { type: "image"; url: string }>((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const rawType = readArchivedString(record, ["type"]);
+    if (!rawType) {
+      return [];
+    }
+
+    switch (rawType) {
+      case "input_text":
+      case "output_text": {
+        const text = readArchivedString(record, ["text"]);
+        return text
+          ? [
+              {
+                type: "text",
+                text,
+              },
+            ]
+          : [];
+      }
+
+      case "input_image":
+      case "output_image": {
+        const url = readArchivedString(record, ["image_url", "imageUrl", "url"]);
+        return url
+          ? [
+              {
+                type: "image",
+                url,
+              },
+            ]
+          : [];
+      }
+
+      default:
+        return [];
+    }
+  });
+}
+
+function normalizeArchivedAssistantMessageText(value: unknown): string | null {
+  const textParts = normalizeArchivedMessageContent(value)
+    .filter((item): item is { type: "text"; text: string } => item.type === "text")
+    .map((item) => item.text);
+  if (textParts.length === 0) {
+    return null;
+  }
+  return textParts.join("\n\n");
+}
+
+function normalizeArchivedToolName(value: unknown): string {
+  if (typeof value !== "string") {
+    return "legacyTool";
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : "legacyTool";
+}
+
+function normalizeArchivedToolArguments(value: unknown): ArchivedJsonValue {
+  if (typeof value === "string") {
+    const parsed = tryParseArchivedJson(value);
+    if (parsed !== undefined) {
+      return normalizeArchivedToolJsonValue(parsed);
+    }
+  }
+  return normalizeArchivedToolJsonValue(value);
+}
+
+function normalizeArchivedToolJsonValue(
+  value: unknown,
+  maxLength = ARCHIVED_TOOL_ARGUMENT_PREVIEW_MAX_CHARS,
+): ArchivedJsonValue {
+  const jsonValue = coerceArchivedJsonValue(value);
+  if (jsonValue === undefined) {
+    return truncateArchivedTextPreview(String(value), maxLength);
+  }
+
+  const serialized =
+    typeof jsonValue === "string" ? jsonValue : JSON.stringify(jsonValue);
+  if (!serialized || serialized.length <= maxLength) {
+    return jsonValue;
+  }
+
+  return `${serialized.slice(0, maxLength)}...`;
+}
+
+function coerceArchivedJsonValue(value: unknown): ArchivedJsonValue | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const result: ArchivedJsonValue[] = [];
+    for (const entry of value) {
+      const normalized = coerceArchivedJsonValue(entry);
+      if (normalized === undefined) {
+        continue;
+      }
+      result.push(normalized);
+    }
+    return result;
+  }
+
+  if (typeof value !== "object") {
+    return undefined;
+  }
+
+  const result: Record<string, ArchivedJsonValue> = {};
+  for (const [key, nestedValue] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    const normalized = coerceArchivedJsonValue(nestedValue);
+    if (normalized === undefined) {
+      continue;
+    }
+    result[key] = normalized;
+  }
+  return result;
+}
+
+function tryParseArchivedJson(value: string): unknown | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  if (!/^[{\["0-9tfn-]/.test(trimmed)) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeArchivedToolSuccess(
+  value: unknown,
+  fallback: boolean | null,
+): boolean | null {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const nestedSuccess = (value as Record<string, unknown>)["success"];
+    if (typeof nestedSuccess === "boolean") {
+      return nestedSuccess;
+    }
+  }
+
+  return fallback;
+}
+
+function normalizeArchivedToolStatus(
+  value: unknown,
+  success: boolean | null,
+  fallback: ArchivedDynamicToolCallItem["status"],
+): ArchivedDynamicToolCallItem["status"] {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase().replace(/[-_\s]+/g, "");
+    if (
+      normalized === "inprogress" ||
+      normalized === "running" ||
+      normalized === "pending"
+    ) {
+      return "inProgress";
+    }
+    if (
+      normalized === "completed" ||
+      normalized === "complete" ||
+      normalized === "success" ||
+      normalized === "succeeded"
+    ) {
+      return "completed";
+    }
+    if (
+      normalized === "failed" ||
+      normalized === "failure" ||
+      normalized === "error" ||
+      normalized === "errored"
+    ) {
+      return "failed";
+    }
+  }
+
+  if (success === true) {
+    return "completed";
+  }
+  if (success === false) {
+    return "failed";
+  }
+  return fallback;
+}
+
+function normalizeArchivedToolContentItems(
+  value: unknown,
+): ArchivedDynamicToolContentItem[] | null {
+  const body =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? ((value as Record<string, unknown>)["body"] ?? value)
+      : value;
+
+  if (Array.isArray(body)) {
+    const items = body
+      .map(normalizeArchivedToolContentItem)
+      .filter(
+        (item): item is ArchivedDynamicToolContentItem => item !== null,
+      );
+    return items.length > 0 ? items : null;
+  }
+
+  if (body === null || body === undefined) {
+    return null;
+  }
+
+  return [normalizeFallbackArchivedToolContentItem(body)];
+}
+
+function normalizeArchivedToolContentItem(
+  value: unknown,
+): ArchivedDynamicToolContentItem | null {
+  if (!value || typeof value !== "object") {
+    return normalizeFallbackArchivedToolContentItem(value);
+  }
+
+  const record = value as Record<string, unknown>;
+  const rawType = readArchivedString(record, ["type"]);
+  if (!rawType) {
+    return normalizeFallbackArchivedToolContentItem(value);
+  }
+
+  switch (rawType) {
+    case "inputText":
+    case "input_text": {
+      const text = readArchivedString(record, ["text"]);
+      if (!text) {
+        return null;
+      }
+      return {
+        type: "inputText",
+        text: truncateArchivedTextPreview(
+          text,
+          ARCHIVED_TOOL_TEXT_PREVIEW_MAX_CHARS,
+        ),
+      };
+    }
+
+    case "inputImage":
+    case "input_image": {
+      const imageUrl = readArchivedString(record, ["imageUrl", "image_url"]);
+      if (!imageUrl) {
+        return null;
+      }
+      return {
+        type: "inputImage",
+        imageUrl,
+      };
+    }
+
+    default:
+      return normalizeFallbackArchivedToolContentItem(value);
+  }
+}
+
+function normalizeFallbackArchivedToolContentItem(
+  value: unknown,
+): ArchivedDynamicToolContentItem {
+  return {
+    type: "inputText",
+    text: truncateArchivedTextPreview(
+      typeof value === "string" ? value : JSON.stringify(value),
+      ARCHIVED_TOOL_TEXT_PREVIEW_MAX_CHARS,
+    ),
+  };
+}
+
+function normalizeArchivedWebSearchContent(
+  value: unknown,
+): Array<{ type: "inputText"; text: string }> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const query = readArchivedString(record, ["query"]);
+  const queriesValue = record["queries"];
+  const queries = Array.isArray(queriesValue)
+    ? queriesValue.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && entry.trim().length > 0,
+      )
+    : [];
+  const lines = query ? [query, ...queries] : queries;
+  const uniqueLines = [...new Set(lines)];
+  if (uniqueLines.length === 0) {
+    return null;
+  }
+
+  return uniqueLines.map((line) => ({
+    type: "inputText",
+    text: truncateArchivedTextPreview(
+      line,
+      ARCHIVED_TOOL_TEXT_PREVIEW_MAX_CHARS,
+    ),
+  }));
+}
+
+function truncateArchivedTextPreview(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}...`;
+}
+
+function normalizeArchivedTodoPlan(
+  value: unknown,
+): ArchivedTodoListItem["plan"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+    const record = entry as Record<string, unknown>;
+    const step = readArchivedString(record, ["step"]);
+    const status = readArchivedString(record, ["status"]);
+    if (!step || !status) {
+      return [];
+    }
+    return [{ step, status }];
+  });
+}
+
+function parseArchivedDurationToMs(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.round(value);
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    return Math.round(numeric);
+  }
+
+  const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/i.exec(
+    trimmed,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number(match[1] ?? 0);
+  const minutes = Number(match[2] ?? 0);
+  const seconds = Number(match[3] ?? 0);
+  if (
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes) ||
+    !Number.isFinite(seconds)
+  ) {
+    return null;
+  }
+  return Math.round(((hours * 60 * 60) + (minutes * 60) + seconds) * 1000);
 }
 
 const INVALID_REQUEST_ERROR_CODE = -32600;
@@ -1463,4 +2767,136 @@ function extractThreadId(frame: IpcFrame): string | null {
   }
 
   return null;
+}
+
+async function readThreadIndexMetadata(
+  threadId: string,
+): Promise<ArchivedThreadIndexMetadata | null> {
+  const codexHomes = getCodexHomeCandidates();
+  for (const codexHome of codexHomes) {
+    const indexPath = path.join(codexHome, "session_index.jsonl");
+    try {
+      const content = await readFile(indexPath, "utf8");
+      for (const line of content.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+        if (parsed["id"] !== threadId) {
+          continue;
+        }
+        const parsedThreadName = parsed["thread_name"];
+        const parsedUpdatedAt = parsed["updated_at"];
+        return {
+          title:
+            typeof parsedThreadName === "string" ? parsedThreadName : null,
+          updatedAt: parseTimestampToUnixSeconds(
+            typeof parsedUpdatedAt === "string" ? parsedUpdatedAt : undefined,
+          ),
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+async function findArchivedRolloutPath(threadId: string): Promise<string | null> {
+  for (const codexHome of getCodexHomeCandidates()) {
+    const archivedSessionsDir = path.join(codexHome, "archived_sessions");
+    const archivedRollout = await findRolloutPathInDirectory(
+      archivedSessionsDir,
+      threadId,
+      0,
+    );
+    if (archivedRollout) {
+      return archivedRollout;
+    }
+
+    const sessionsDir = path.join(codexHome, "sessions");
+    const activeRollout = await findRolloutPathInDirectory(sessionsDir, threadId, 4);
+    if (activeRollout) {
+      return activeRollout;
+    }
+  }
+
+  return null;
+}
+
+async function findRolloutPathInDirectory(
+  directory: string,
+  threadId: string,
+  remainingDepth: number,
+): Promise<string | null> {
+  try {
+    await access(directory);
+  } catch {
+    return null;
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (!entry.name.endsWith(".jsonl") || !entry.name.includes(threadId)) {
+      continue;
+    }
+    return path.join(directory, entry.name);
+  }
+
+  if (remainingDepth <= 0) {
+    return null;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const nested = await findRolloutPathInDirectory(
+      path.join(directory, entry.name),
+      threadId,
+      remainingDepth - 1,
+    );
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function getCodexHomeCandidates(): string[] {
+  const candidates = [
+    process.env["CODEX_HOME"],
+    process.env["USERPROFILE"]
+      ? path.join(process.env["USERPROFILE"], ".codex")
+      : null,
+    process.env["HOME"] ? path.join(process.env["HOME"], ".codex") : null,
+    path.join(os.homedir(), ".codex"),
+  ];
+
+  const unique = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || candidate.trim().length === 0) {
+      continue;
+    }
+    unique.add(candidate);
+  }
+  return [...unique];
+}
+
+function parseTimestampToUnixSeconds(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) {
+    return null;
+  }
+  return Math.floor(milliseconds / 1000);
 }

--- a/apps/server/src/debug-history.ts
+++ b/apps/server/src/debug-history.ts
@@ -4,6 +4,7 @@ const MAX_HISTORY_OBJECT_KEYS = 24;
 const MAX_HISTORY_TURN_PREVIEW_COUNT = 16;
 const MAX_HISTORY_ITEM_PREVIEW_COUNT = 20;
 const MAX_HISTORY_PATCH_PREVIEW_COUNT = 24;
+const MAX_HISTORY_COMPACT_DEPTH = 6;
 
 export interface StoredHistoryPayload {
   json: string;
@@ -120,7 +121,7 @@ function compactConversationState(
     turns: retainedTurns.map((turn, index) =>
       compactTurn(turn, retainedTurns.length - 1 - index),
     ),
-    requests: compactArray(requests, 1),
+    requests: compactArray(requests, 1, new WeakSet<object>()),
     ...(turns.length > MAX_HISTORY_TURN_PREVIEW_COUNT
       ? {
           truncatedTurnCount:
@@ -253,7 +254,11 @@ function compactPatch(patch: unknown, index: number): unknown {
   };
 }
 
-function compactJsonValue(value: unknown, depth: number): unknown {
+function compactJsonValue(
+  value: unknown,
+  depth: number,
+  seen = new WeakSet<object>(),
+): unknown {
   if (value === null || value === undefined) {
     return value;
   }
@@ -274,11 +279,27 @@ function compactJsonValue(value: unknown, depth: number): unknown {
   }
 
   if (Array.isArray(value)) {
-    return compactArray(value, depth + 1);
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    if (depth >= MAX_HISTORY_COMPACT_DEPTH) {
+      return [{ __truncatedDepth: true }];
+    }
+    return compactArray(value, depth + 1, seen);
   }
 
   if (!isRecord(value)) {
     return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+
+  if (depth >= MAX_HISTORY_COMPACT_DEPTH) {
+    return { __truncatedDepth: true };
   }
 
   const entries = Object.entries(value);
@@ -286,7 +307,7 @@ function compactJsonValue(value: unknown, depth: number): unknown {
   const result: Record<string, unknown> = {};
 
   for (const [key, nestedValue] of limitedEntries) {
-    result[key] = compactJsonValue(nestedValue, depth + 1);
+    result[key] = compactJsonValue(nestedValue, depth + 1, seen);
   }
 
   if (entries.length > MAX_HISTORY_OBJECT_KEYS) {
@@ -294,16 +315,21 @@ function compactJsonValue(value: unknown, depth: number): unknown {
       entries.length - MAX_HISTORY_OBJECT_KEYS;
   }
 
-  if (depth >= 6) {
-    result["__truncatedDepth"] = true;
-  }
-
   return result;
 }
 
-function compactArray(values: unknown[], depth: number): unknown[] {
+function compactArray(
+  values: unknown[],
+  depth: number,
+  seen: WeakSet<object>,
+): unknown[] {
+  if (depth >= MAX_HISTORY_COMPACT_DEPTH) {
+    return [{ __truncatedDepth: true }];
+  }
   const limitedValues = values.slice(0, MAX_HISTORY_ARRAY_ITEMS);
-  const result = limitedValues.map((value) => compactJsonValue(value, depth + 1));
+  const result = limitedValues.map((value) =>
+    compactJsonValue(value, depth + 1, seen),
+  );
 
   if (values.length > MAX_HISTORY_ARRAY_ITEMS) {
     result.push({

--- a/apps/server/src/debug-history.ts
+++ b/apps/server/src/debug-history.ts
@@ -1,0 +1,367 @@
+const MAX_HISTORY_STRING_LENGTH = 512;
+const MAX_HISTORY_ARRAY_ITEMS = 24;
+const MAX_HISTORY_OBJECT_KEYS = 24;
+const MAX_HISTORY_TURN_PREVIEW_COUNT = 16;
+const MAX_HISTORY_ITEM_PREVIEW_COUNT = 20;
+const MAX_HISTORY_PATCH_PREVIEW_COUNT = 24;
+
+export interface StoredHistoryPayload {
+  json: string;
+  originalBytes: number;
+  storedBytes: number;
+  compacted: boolean;
+}
+
+export function prepareHistoryPayloadForStorage(
+  payload: unknown,
+): StoredHistoryPayload {
+  const originalJson = safeJsonStringify(payload);
+  let compactedPayload: unknown;
+  try {
+    compactedPayload = compactHistoryPayload(payload);
+  } catch {
+    compactedPayload = payload;
+  }
+  const compactedJson = safeJsonStringify(compactedPayload);
+  const originalBytes = Buffer.byteLength(originalJson, "utf8");
+  const storedBytes = Buffer.byteLength(compactedJson, "utf8");
+
+  return {
+    json: compactedJson,
+    originalBytes,
+    storedBytes,
+    compacted: compactedJson !== originalJson,
+  };
+}
+
+function compactHistoryPayload(payload: unknown): unknown {
+  if (!isRecord(payload)) {
+    return compactJsonValue(payload, 0);
+  }
+
+  if (payload["method"] === "thread-stream-state-changed") {
+    return compactThreadStreamStateChangedPayload(payload);
+  }
+
+  return compactJsonValue(payload, 0);
+}
+
+function compactThreadStreamStateChangedPayload(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  const params = asRecord(payload["params"]);
+  const change = asRecord(params?.["change"]);
+
+  if (!params || !change) {
+    return compactJsonValue(payload, 0) as Record<string, unknown>;
+  }
+
+  if (change["type"] === "snapshot") {
+    const conversationState = asRecord(change["conversationState"]);
+    if (!conversationState) {
+      return compactJsonValue(payload, 0) as Record<string, unknown>;
+    }
+
+    return {
+      ...payload,
+      params: {
+        ...params,
+        change: {
+          ...change,
+          conversationState: compactConversationState(conversationState),
+        },
+      },
+    };
+  }
+
+  if (change["type"] === "patches") {
+    const patches = Array.isArray(change["patches"]) ? change["patches"] : [];
+    return {
+      ...payload,
+      params: {
+        ...params,
+        change: {
+          ...change,
+          patchCount: patches.length,
+          patches: patches
+            .slice(0, MAX_HISTORY_PATCH_PREVIEW_COUNT)
+            .map((patch, index) => compactPatch(patch, index)),
+          ...(patches.length > MAX_HISTORY_PATCH_PREVIEW_COUNT
+            ? {
+                truncatedPatchCount:
+                  patches.length - MAX_HISTORY_PATCH_PREVIEW_COUNT,
+              }
+            : {}),
+        },
+      },
+    };
+  }
+
+  return compactJsonValue(payload, 0) as Record<string, unknown>;
+}
+
+function compactConversationState(
+  conversationState: Record<string, unknown>,
+): Record<string, unknown> {
+  const turns = Array.isArray(conversationState["turns"])
+    ? conversationState["turns"]
+    : [];
+  const requests = Array.isArray(conversationState["requests"])
+    ? conversationState["requests"]
+    : [];
+  const retainedTurns = turns.slice(
+    Math.max(0, turns.length - MAX_HISTORY_TURN_PREVIEW_COUNT),
+  );
+
+  return {
+    ...conversationState,
+    turnCount: turns.length,
+    requestCount: requests.length,
+    turns: retainedTurns.map((turn, index) =>
+      compactTurn(turn, retainedTurns.length - 1 - index),
+    ),
+    requests: compactArray(requests, 1),
+    ...(turns.length > MAX_HISTORY_TURN_PREVIEW_COUNT
+      ? {
+          truncatedTurnCount:
+            turns.length - MAX_HISTORY_TURN_PREVIEW_COUNT,
+        }
+      : {}),
+  };
+}
+
+function compactTurn(turn: unknown, reverseIndex: number): unknown {
+  if (!isRecord(turn)) {
+    return compactJsonValue(turn, 0);
+  }
+
+  const items = Array.isArray(turn["items"]) ? turn["items"] : [];
+  return {
+    ...(typeof turn["turnId"] === "string" ? { turnId: turn["turnId"] } : {}),
+    ...(typeof turn["status"] === "string" ? { status: turn["status"] } : {}),
+    ...(turn["error"] !== undefined
+      ? { error: compactJsonValue(turn["error"], 1) }
+      : {}),
+    itemCount: items.length,
+    itemTypes: items.map((item) =>
+      isRecord(item) && typeof item["type"] === "string"
+        ? item["type"]
+        : "<unknown>",
+    ),
+    items: items
+      .slice(Math.max(0, items.length - MAX_HISTORY_ITEM_PREVIEW_COUNT))
+      .map((item) => compactTurnItem(item)),
+    ...(items.length > MAX_HISTORY_ITEM_PREVIEW_COUNT
+      ? {
+          truncatedItemCount:
+            items.length - MAX_HISTORY_ITEM_PREVIEW_COUNT,
+        }
+      : {}),
+    ...(turn["params"] !== undefined
+      ? { params: compactJsonValue(turn["params"], 1) }
+      : {}),
+    ...(turn["turnStartedAtMs"] !== undefined
+      ? { turnStartedAtMs: turn["turnStartedAtMs"] }
+      : {}),
+    ...(turn["finalAssistantStartedAtMs"] !== undefined
+      ? { finalAssistantStartedAtMs: turn["finalAssistantStartedAtMs"] }
+      : {}),
+    turnOffsetFromLatest: reverseIndex,
+  };
+}
+
+function compactTurnItem(item: unknown): unknown {
+  if (!isRecord(item)) {
+    return compactJsonValue(item, 0);
+  }
+
+  const base = {
+    ...(typeof item["id"] === "string" ? { id: item["id"] } : {}),
+    ...(typeof item["type"] === "string" ? { type: item["type"] } : {}),
+  };
+
+  switch (item["type"]) {
+    case "userMessage":
+    case "steeringUserMessage":
+      return {
+        ...base,
+        ...(item["attachments"] !== undefined
+          ? { attachments: compactJsonValue(item["attachments"], 1) }
+          : {}),
+        content: compactJsonValue(item["content"], 1),
+      };
+    case "agentMessage":
+      return {
+        ...base,
+        ...(typeof item["phase"] === "string"
+          ? { phase: item["phase"] }
+          : {}),
+        ...(typeof item["text"] === "string"
+          ? { text: compactString(item["text"]) }
+          : {}),
+      };
+    case "reasoning":
+      return {
+        ...base,
+        ...(item["summary"] !== undefined
+          ? { summary: compactJsonValue(item["summary"], 1) }
+          : {}),
+        ...(typeof item["text"] === "string"
+          ? { text: compactString(item["text"]) }
+          : {}),
+      };
+    case "error":
+      return {
+        ...base,
+        ...(typeof item["message"] === "string"
+          ? { message: compactString(item["message"]) }
+          : {}),
+        ...(item["errorInfo"] !== undefined
+          ? { errorInfo: compactJsonValue(item["errorInfo"], 1) }
+          : {}),
+        ...(item["additionalDetails"] !== undefined
+          ? {
+              additionalDetails: compactJsonValue(
+                item["additionalDetails"],
+                1,
+              ),
+            }
+          : {}),
+      };
+    default:
+      return compactJsonValue(item, 1);
+  }
+}
+
+function compactPatch(patch: unknown, index: number): unknown {
+  if (!isRecord(patch)) {
+    return compactJsonValue(patch, 0);
+  }
+
+  return {
+    index,
+    ...(typeof patch["op"] === "string" ? { op: patch["op"] } : {}),
+    ...(patch["path"] !== undefined
+      ? { path: compactJsonValue(patch["path"], 1) }
+      : {}),
+    ...(patch["value"] !== undefined
+      ? { value: compactJsonValue(patch["value"], 1) }
+      : {}),
+    ...(patch["from"] !== undefined
+      ? { from: compactJsonValue(patch["from"], 1) }
+      : {}),
+  };
+}
+
+function compactJsonValue(value: unknown, depth: number): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return compactString(value);
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return compactArray(value, depth + 1);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const entries = Object.entries(value);
+  const limitedEntries = entries.slice(0, MAX_HISTORY_OBJECT_KEYS);
+  const result: Record<string, unknown> = {};
+
+  for (const [key, nestedValue] of limitedEntries) {
+    result[key] = compactJsonValue(nestedValue, depth + 1);
+  }
+
+  if (entries.length > MAX_HISTORY_OBJECT_KEYS) {
+    result["__truncatedKeyCount"] =
+      entries.length - MAX_HISTORY_OBJECT_KEYS;
+  }
+
+  if (depth >= 6) {
+    result["__truncatedDepth"] = true;
+  }
+
+  return result;
+}
+
+function compactArray(values: unknown[], depth: number): unknown[] {
+  const limitedValues = values.slice(0, MAX_HISTORY_ARRAY_ITEMS);
+  const result = limitedValues.map((value) => compactJsonValue(value, depth + 1));
+
+  if (values.length > MAX_HISTORY_ARRAY_ITEMS) {
+    result.push({
+      __truncatedArrayItems: values.length - MAX_HISTORY_ARRAY_ITEMS,
+    });
+  }
+
+  return result;
+}
+
+function compactString(value: string): string {
+  if (value.length <= MAX_HISTORY_STRING_LENGTH) {
+    return value;
+  }
+
+  const truncatedLength = value.length - MAX_HISTORY_STRING_LENGTH;
+  return `${value.slice(0, MAX_HISTORY_STRING_LENGTH)}... [${truncatedLength} chars truncated]`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function safeJsonStringify(value: unknown): string {
+  const rootValue = normalizeJsonRootValue(value);
+  const seen = new WeakSet<object>();
+  const serialized = JSON.stringify(
+    rootValue,
+    (_key, nestedValue) => {
+      if (typeof nestedValue === "bigint") {
+        return nestedValue.toString();
+      }
+      if (typeof nestedValue === "object" && nestedValue !== null) {
+        if (seen.has(nestedValue)) {
+          return "[Circular]";
+        }
+        seen.add(nestedValue);
+      }
+      return nestedValue;
+    },
+    2,
+  );
+  return serialized ?? "null";
+}
+
+function normalizeJsonRootValue(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "function" || typeof value === "symbol") {
+    return String(value);
+  }
+  return value;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,6 +16,7 @@ import {
   TraceMarkBodySchema,
   TraceStartBodySchema,
 } from "./http-schemas.js";
+import { prepareHistoryPayloadForStorage } from "./debug-history.js";
 import { logger } from "./logger.js";
 import {
   parseServerCliOptions,
@@ -34,7 +35,7 @@ import {
 
 const HOST = process.env["HOST"] ?? "127.0.0.1";
 const PORT = Number(process.env["PORT"] ?? 4311);
-const HISTORY_LIMIT = 2_000;
+const HISTORY_LIMIT = 400;
 const USER_AGENT = "farfield/0.2.2";
 const IPC_RECONNECT_DELAY_MS = 1_000;
 const SIDEBAR_PREVIEW_MAX_CHARS = 180;
@@ -47,7 +48,6 @@ interface HistoryEntry {
   at: string;
   source: "ipc" | "app" | "system";
   direction: "in" | "out" | "system";
-  payload: unknown;
   meta: Record<string, unknown>;
 }
 
@@ -76,6 +76,31 @@ interface ActiveTrace {
 function resolveCodexExecutablePath(): string {
   if (process.env["CODEX_CLI_PATH"]) {
     return process.env["CODEX_CLI_PATH"];
+  }
+
+  if (process.platform === "win32") {
+    const windowsCandidates = [
+      "codex.ps1",
+      "codex.cmd",
+      "codex",
+      "codex.exe",
+    ];
+
+    for (const candidate of windowsCandidates) {
+      try {
+        const resolved = execFileSync("where.exe", [candidate], {
+          encoding: "utf8",
+        })
+          .split(/\r?\n/)
+          .map((entry) => entry.trim())
+          .find((entry) => entry.length > 0);
+        if (resolved) {
+          return resolved;
+        }
+      } catch {
+        // Try the next candidate.
+      }
+    }
   }
 
   const desktopPath = "/Applications/Codex.app/Contents/Resources/codex";
@@ -238,7 +263,7 @@ const ipcSocketPath = resolveIpcSocketPath();
 const gitCommit = resolveGitCommitHash();
 
 const history: HistoryEntry[] = [];
-const historyById = new Map<string, unknown>();
+const historyById = new Map<string, string>();
 const unifiedSseClients = new Set<ServerResponse>();
 const activeSockets = new Set<Socket>();
 const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
@@ -263,17 +288,22 @@ function pushHistory(
   payload: unknown,
   meta: Record<string, unknown> = {},
 ): HistoryEntry {
+  const storedPayload = prepareHistoryPayloadForStorage(payload);
   const entry: HistoryEntry = {
     id: randomUUID(),
     at: new Date().toISOString(),
     source,
     direction,
-    payload,
-    meta,
+    meta: {
+      ...meta,
+      payloadBytes: storedPayload.originalBytes,
+      storedPayloadBytes: storedPayload.storedBytes,
+      payloadCompacted: storedPayload.compacted,
+    },
   };
 
   history.push(entry);
-  historyById.set(entry.id, payload);
+  historyById.set(entry.id, storedPayload.json);
 
   if (history.length > HISTORY_LIMIT) {
     const removed = history.shift();
@@ -282,7 +312,11 @@ function pushHistory(
     }
   }
 
-  recordTraceEvent({ type: "history", ...entry });
+  recordTraceEvent({
+    type: "history",
+    ...entry,
+    payloadJson: storedPayload.json,
+  });
   return entry;
 }
 
@@ -336,6 +370,7 @@ const unifiedAdapters = createUnifiedProviderAdapters({
 
 function getRuntimeStateSnapshot(): Record<string, unknown> {
   const codexRuntimeState = codexAdapter?.getRuntimeState();
+  const codexRuntimeCounts = codexAdapter?.getTrackedThreadRuntimeCounts();
 
   return {
     appExecutable: codexExecutable,
@@ -348,6 +383,25 @@ function getRuntimeStateSnapshot(): Record<string, unknown> {
     lastError: runtimeLastError ?? codexRuntimeState?.lastError ?? null,
     historyCount: history.length,
     threadOwnerCount: codexAdapter?.getThreadOwnerCount() ?? 0,
+    trackedThreadCount: codexRuntimeCounts?.trackedThreadCount ?? 0,
+    streamEventThreadCount: codexRuntimeCounts?.streamEventThreadCount ?? 0,
+    totalBufferedStreamEventCount:
+      codexRuntimeCounts?.totalBufferedStreamEventCount ?? 0,
+    streamSnapshotThreadCount:
+      codexRuntimeCounts?.streamSnapshotThreadCount ?? 0,
+    threadTitleCount: codexRuntimeCounts?.threadTitleCount ?? 0,
+    maxTrackedThreadCountSeen:
+      codexRuntimeCounts?.maxTrackedThreadCountSeen ?? 0,
+    maxTotalBufferedStreamEventCountSeen:
+      codexRuntimeCounts?.maxTotalBufferedStreamEventCountSeen ?? 0,
+    maxBufferedStreamEventsPerThreadSeen:
+      codexRuntimeCounts?.maxBufferedStreamEventsPerThreadSeen ?? 0,
+    archivedRestoreHitCount: codexRuntimeCounts?.archivedRestoreHitCount ?? 0,
+    archivedRestoreFailureCount:
+      codexRuntimeCounts?.archivedRestoreFailureCount ?? 0,
+    streamParseFailureCount: codexRuntimeCounts?.streamParseFailureCount ?? 0,
+    streamReductionFailureCount:
+      codexRuntimeCounts?.streamReductionFailureCount ?? 0,
     activeTrace: activeTrace?.summary ?? null,
   };
 }
@@ -818,6 +872,10 @@ const server = http.createServer(async (req, res) => {
         url.searchParams.get("includeTurns"),
         true,
       );
+      const maxRenderableItems = parseInteger(
+        url.searchParams.get("maxRenderableItems"),
+        0,
+      );
       const knownProviders = threadIndex.providers(threadId);
       const resolvedProvider = threadIndex.resolve(threadId);
       const provider = providerFromQuery ?? resolvedProvider;
@@ -872,6 +930,9 @@ const server = http.createServer(async (req, res) => {
           provider,
           threadId,
           includeTurns,
+          ...(maxRenderableItems > 0
+            ? { maxRenderableItems }
+            : {}),
         });
 
         threadIndex.register(result.thread.id, result.thread.provider);
@@ -890,6 +951,9 @@ const server = http.createServer(async (req, res) => {
               provider,
               threadId,
               includeTurns,
+              ...(maxRenderableItems > 0
+                ? { maxRenderableItems }
+                : {}),
             },
           },
         });
@@ -912,7 +976,7 @@ const server = http.createServer(async (req, res) => {
         jsonResponse(res, 200, {
           ok: true,
           entry: toDebugHistoryListEntry(entry),
-          fullPayloadJson: JSON.stringify(historyById.get(entryId) ?? null, null, 2),
+          fullPayloadJson: historyById.get(entryId) ?? "null",
         });
         return;
       }

--- a/apps/server/src/unified/adapter.ts
+++ b/apps/server/src/unified/adapter.ts
@@ -59,6 +59,10 @@ export const FEATURE_ID_BY_COMMAND_KIND: Record<
   listProjectDirectories: "listProjectDirectories",
 };
 
+const DYNAMIC_TOOL_ARGUMENT_PREVIEW_MAX_CHARS = 600;
+const MCP_TOOL_ARGUMENT_PREVIEW_MAX_CHARS = 600;
+const MCP_TOOL_STRUCTURED_CONTENT_PREVIEW_MAX_CHARS = 600;
+
 const PROVIDER_FEATURE_SUPPORT: Record<
   UnifiedProviderId,
   Record<UnifiedFeatureId, boolean>
@@ -92,6 +96,105 @@ const PROVIDER_FEATURE_SUPPORT: Record<
     listProjectDirectories: true,
   },
 };
+
+function humanizeCollaborationModeLabel(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return "Default";
+  }
+
+  return trimmed
+    .replace(/[-_]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function hasRenderableUnifiedUserMessageContent(
+  item: Extract<UnifiedItem, { type: "userMessage" | "steeringUserMessage" }>,
+): boolean {
+  return item.content.some((part) => {
+    if (part.type === "text") {
+      return part.text.length > 0;
+    }
+    return part.url.length > 0;
+  });
+}
+
+function shouldCountRenderableUnifiedItem(item: UnifiedItem): boolean {
+  switch (item.type) {
+    case "userMessage":
+    case "steeringUserMessage":
+      return hasRenderableUnifiedUserMessageContent(item);
+    case "agentMessage":
+      return item.text.length > 0;
+    case "reasoning":
+      return (item.summary?.length ?? 0) > 0 || Boolean(item.text);
+    case "userInputResponse":
+      return Object.values(item.answers).some((answers) => answers.length > 0);
+    default:
+      return true;
+  }
+}
+
+function trimUnifiedThreadForRenderableItems(
+  thread: UnifiedThread,
+  maxRenderableItems: number,
+): UnifiedThread {
+  if (maxRenderableItems <= 0 || thread.turns.length === 0) {
+    return thread;
+  }
+
+  const renderableBudget = maxRenderableItems + 1;
+  let renderableCount = 0;
+  let firstTurnIndex = -1;
+  let firstItemIndex = -1;
+
+  for (
+    let turnIndex = thread.turns.length - 1;
+    turnIndex >= 0;
+    turnIndex -= 1
+  ) {
+    const turn = thread.turns[turnIndex];
+    if (!turn) {
+      continue;
+    }
+    const items = turn.items ?? [];
+    for (let itemIndex = items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      const item = items[itemIndex];
+      if (!item || !shouldCountRenderableUnifiedItem(item)) {
+        continue;
+      }
+      renderableCount += 1;
+      if (renderableCount === renderableBudget) {
+        firstTurnIndex = turnIndex;
+        firstItemIndex = itemIndex;
+      }
+    }
+  }
+
+  if (
+    renderableCount <= renderableBudget ||
+    firstTurnIndex === -1 ||
+    firstItemIndex === -1
+  ) {
+    return thread;
+  }
+
+  return {
+    ...thread,
+    turns: thread.turns.slice(firstTurnIndex).map((turn, index) => {
+      if (index !== 0) {
+        return turn;
+      }
+      return {
+        ...turn,
+        items: (turn.items ?? []).slice(firstItemIndex),
+      };
+    }),
+  };
+}
 
 export class UnifiedBackendFeatureError extends Error {
   public readonly provider: UnifiedProviderId;
@@ -265,10 +368,17 @@ function createHandlerTable(
         threadId: command.threadId,
         includeTurns: command.includeTurns,
       });
+      const mappedThread = mapThread(provider, result.thread);
 
       return {
         kind: "readThread",
-        thread: mapThread(provider, result.thread),
+        thread:
+          typeof command.maxRenderableItems === "number"
+            ? trimUnifiedThreadForRenderableItems(
+                mappedThread,
+                command.maxRenderableItems,
+              )
+            : mappedThread,
       };
     },
 
@@ -317,8 +427,8 @@ function createHandlerTable(
         kind: "listModels",
         data: result.data.map((model) => ({
           id: model.id,
-          displayName: model.displayName,
-          description: model.description,
+          displayName: model.displayName ?? model.id,
+          description: model.description ?? "",
           defaultReasoningEffort: model.defaultReasoningEffort ?? null,
           supportedReasoningEfforts: model.supportedReasoningEfforts.map(
             (entry) => entry.reasoningEffort,
@@ -342,12 +452,28 @@ function createHandlerTable(
       return {
         kind: "listCollaborationModes",
         data: result.data.map((mode) => ({
-          name: mode.name,
+          name:
+            mode.name ??
+            humanizeCollaborationModeLabel(mode.mode ?? "default"),
           mode: mode.mode ?? "default",
-          ...(mode.model !== undefined ? { model: mode.model } : {}),
+          ...(mode.model !== undefined
+            ? { model: mode.model }
+            : mode.settings?.model !== undefined
+              ? { model: mode.settings.model }
+              : {}),
           ...(mode.reasoning_effort !== undefined
             ? { reasoningEffort: mode.reasoning_effort }
-            : {}),
+            : mode.settings?.reasoning_effort !== undefined
+              ? { reasoningEffort: mode.settings.reasoning_effort }
+              : {}),
+          ...(mode.developer_instructions !== undefined
+            ? { developerInstructions: mode.developer_instructions }
+            : mode.settings?.developer_instructions !== undefined
+              ? {
+                  developerInstructions:
+                    mode.settings.developer_instructions,
+                }
+              : {}),
         })),
       };
     },
@@ -430,13 +556,21 @@ function createHandlerTable(
       }
 
       const liveState = await adapter.readLiveState(command.threadId);
+      const mappedConversationState = liveState.conversationState
+        ? mapThread(provider, liveState.conversationState)
+        : null;
       return {
         kind: "readLiveState",
         threadId: command.threadId,
         ownerClientId: liveState.ownerClientId,
-        conversationState: liveState.conversationState
-          ? mapThread(provider, liveState.conversationState)
-          : null,
+        conversationState:
+          mappedConversationState &&
+          typeof command.maxRenderableItems === "number"
+            ? trimUnifiedThreadForRenderableItems(
+                mappedConversationState,
+                command.maxRenderableItems,
+              )
+            : mappedConversationState,
         ...(liveState.liveStateError
           ? { liveStateError: liveState.liveStateError }
           : {}),
@@ -960,10 +1094,11 @@ function mapTurnItem(
       };
 
     case "todo-list":
+    case "todoList":
       return {
         id: item.id,
         type: "todoList",
-        ...(item.explanation !== undefined
+        ...(item.explanation != null
           ? { explanation: item.explanation }
           : {}),
         plan: item.plan.map((entry) => ({
@@ -1081,21 +1216,23 @@ function mapTurnItem(
         server: item.server,
         tool: item.tool,
         status: item.status,
-        arguments: jsonValueFromString(JSON.stringify(item.arguments)),
+        arguments: buildJsonPreviewString(
+          item.arguments,
+          MCP_TOOL_ARGUMENT_PREVIEW_MAX_CHARS,
+        ),
         ...(item.result !== undefined
           ? {
               result: item.result
                 ? {
-                    content: item.result.content.map((entry) =>
-                      jsonValueFromString(JSON.stringify(entry)),
-                    ),
+                    content: item.result.content.map(() => null),
                     ...(item.result.structuredContent !== undefined
                       ? {
                           structuredContent:
                             item.result.structuredContent === null
                               ? null
-                              : jsonValueFromString(
-                                  JSON.stringify(item.result.structuredContent),
+                              : buildJsonPreviewString(
+                                  item.result.structuredContent,
+                                  MCP_TOOL_STRUCTURED_CONTENT_PREVIEW_MAX_CHARS,
                                 ),
                         }
                       : {}),
@@ -1106,6 +1243,33 @@ function mapTurnItem(
         ...(item.error !== undefined
           ? { error: item.error ? { message: item.error.message } : null }
           : {}),
+        ...(item.durationMs !== undefined
+          ? { durationMs: item.durationMs }
+          : {}),
+      };
+
+    case "dynamicToolCall":
+      return {
+        id: item.id,
+        type: "dynamicToolCall",
+        tool: item.tool,
+        status: item.status,
+        arguments: buildJsonPreviewString(
+          item.arguments,
+          DYNAMIC_TOOL_ARGUMENT_PREVIEW_MAX_CHARS,
+        ),
+        ...(item.contentItems !== undefined
+          ? {
+              contentItems: item.contentItems
+                ? item.contentItems.map((contentItem) =>
+                    contentItem.type === "inputText"
+                      ? { type: "inputText", text: contentItem.text }
+                      : { type: "inputImage", imageUrl: contentItem.imageUrl },
+                  )
+                : null,
+            }
+          : {}),
+        ...(item.success !== undefined ? { success: item.success } : {}),
         ...(item.durationMs !== undefined
           ? { durationMs: item.durationMs }
           : {}),
@@ -1176,6 +1340,29 @@ function mapTurnItem(
 
 function jsonValueFromString(serialized: string): JsonValue {
   return JsonValueSchema.parse(JSON.parse(serialized));
+}
+
+function buildJsonPreviewString(value: unknown, maxLength: number): string {
+  if (typeof value === "string") {
+    return truncatePreviewText(value, maxLength);
+  }
+
+  try {
+    const serialized = JSON.stringify(value);
+    if (!serialized) {
+      return "";
+    }
+    return truncatePreviewText(serialized, maxLength);
+  } catch {
+    return truncatePreviewText(String(value), maxLength);
+  }
+}
+
+function truncatePreviewText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}...`;
 }
 
 function jsonArrayFromString(serialized: string): JsonValue[] {

--- a/apps/server/src/unified/adapter.ts
+++ b/apps/server/src/unified/adapter.ts
@@ -1,5 +1,6 @@
 import {
   assertNever,
+  JsonValueSchema as ProtocolJsonValueSchema,
   type ThreadConversationState,
   UserInputRequestSchema,
 } from "@farfield/protocol";
@@ -36,6 +37,7 @@ type UnifiedCommandResultByKind<K extends UnifiedCommandKind> = Extract<
 type UnifiedCommandHandler<K extends UnifiedCommandKind> = (
   command: UnifiedCommandByKind<K>,
 ) => Promise<UnifiedCommandResultByKind<K>>;
+type ProtocolJsonValue = z.infer<typeof ProtocolJsonValueSchema>;
 
 export type UnifiedCommandHandlerTable = {
   [K in UnifiedCommandKind]: UnifiedCommandHandler<K>;
@@ -133,8 +135,26 @@ function shouldCountRenderableUnifiedItem(item: UnifiedItem): boolean {
       return (item.summary?.length ?? 0) > 0 || Boolean(item.text);
     case "userInputResponse":
       return Object.values(item.answers).some((answers) => answers.length > 0);
-    default:
+    case "error":
+    case "plan":
+    case "todoList":
+    case "planImplementation":
+    case "commandExecution":
+    case "fileChange":
+    case "contextCompaction":
+    case "webSearch":
+    case "mcpToolCall":
+    case "dynamicToolCall":
+    case "collabAgentToolCall":
+    case "imageView":
+    case "enteredReviewMode":
+    case "exitedReviewMode":
+    case "remoteTaskCreated":
+    case "modelChanged":
+    case "forkedFromConversation":
       return true;
+    default:
+      return assertNever(item);
   }
 }
 
@@ -1342,20 +1362,15 @@ function jsonValueFromString(serialized: string): JsonValue {
   return JsonValueSchema.parse(JSON.parse(serialized));
 }
 
-function buildJsonPreviewString(value: unknown, maxLength: number): string {
+function buildJsonPreviewString(
+  value: ProtocolJsonValue,
+  maxLength: number,
+): string {
   if (typeof value === "string") {
     return truncatePreviewText(value, maxLength);
   }
-
-  try {
-    const serialized = JSON.stringify(value);
-    if (!serialized) {
-      return "";
-    }
-    return truncatePreviewText(serialized, maxLength);
-  } catch {
-    return truncatePreviewText(String(value), maxLength);
-  }
+  const serialized = JSON.stringify(value);
+  return serialized ? truncatePreviewText(serialized, maxLength) : "";
 }
 
 function truncatePreviewText(value: string, maxLength: number): string {

--- a/apps/server/test/codex-agent-live-state.test.ts
+++ b/apps/server/test/codex-agent-live-state.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { AppServerClient } from "@farfield/api";
 import type {
   IpcFrame,
   ThreadConversationState,
@@ -526,8 +527,56 @@ describe("buildArchivedThreadConversationStateFromJsonl", () => {
 });
 
 describe("CodexAgentAdapter runtime retention", () => {
-  function createAdapterForTest(): CodexAgentAdapter {
-    return new CodexAgentAdapter({
+  class TestCodexAgentAdapter extends CodexAgentAdapter {
+    public override patchRuntimeState(
+      next: Partial<ReturnType<CodexAgentAdapter["getRuntimeState"]>>,
+    ): void {
+      super.patchRuntimeState(next);
+    }
+
+    public override async restoreArchivedThreadState(
+      threadId: string,
+      includeTurns: boolean,
+    ): Promise<ThreadConversationState | null> {
+      return super.restoreArchivedThreadState(threadId, includeTurns);
+    }
+
+    public override setTrackedThreadOwner(
+      threadId: string,
+      ownerClientId: string,
+    ): void {
+      super.setTrackedThreadOwner(threadId, ownerClientId);
+    }
+
+    public override setTrackedThreadEvents(
+      threadId: string,
+      events: IpcFrame[],
+    ): void {
+      super.setTrackedThreadEvents(threadId, events);
+    }
+
+    public override setTrackedThreadSnapshot(
+      threadId: string,
+      snapshot: ThreadConversationState,
+      origin: "stream" | "readThreadWithTurns" | "readThread",
+    ): void {
+      super.setTrackedThreadSnapshot(threadId, snapshot, origin);
+    }
+
+    public override setThreadTitle(
+      threadId: string,
+      title: string | null | undefined,
+    ): void {
+      super.setThreadTitle(threadId, title);
+    }
+
+    public get appClientForTest(): AppServerClient {
+      return this.appClient;
+    }
+  }
+
+  function createAdapterForTest(): TestCodexAgentAdapter {
+    return new TestCodexAgentAdapter({
       appExecutable: "codex",
       socketPath: "\\\\.\\pipe\\farfield-test",
       workspaceDir: process.cwd(),
@@ -537,18 +586,7 @@ describe("CodexAgentAdapter runtime retention", () => {
   }
 
   it("evicts the oldest tracked thread state after the runtime cap", () => {
-    const adapter = createAdapterForTest() as unknown as {
-      setTrackedThreadOwner: (threadId: string, ownerClientId: string) => void;
-      setTrackedThreadSnapshot: (
-        threadId: string,
-        snapshot: ThreadConversationState,
-        origin: "stream" | "readThreadWithTurns" | "readThread",
-      ) => void;
-      setTrackedThreadEvents: (threadId: string, events: IpcFrame[]) => void;
-      setThreadTitle: (threadId: string, title: string | null) => void;
-      getTrackedThreadRuntimeCounts: CodexAgentAdapter["getTrackedThreadRuntimeCounts"];
-      readStreamEvents: CodexAgentAdapter["readStreamEvents"];
-    };
+    const adapter = createAdapterForTest();
 
     for (let index = 0; index < 82; index += 1) {
       const threadId = `thread-${String(index)}`;
@@ -570,14 +608,36 @@ describe("CodexAgentAdapter runtime retention", () => {
     expect(counts.trackedThreadCount).toBe(80);
     expect(counts.maxTrackedThreadCountSeen).toBe(80);
     expect(counts.streamEventThreadCount).toBe(80);
+
+    return Promise.all([
+      adapter.readStreamEvents("thread-0", 500),
+      adapter.readStreamEvents("thread-1", 500),
+      adapter.readStreamEvents("thread-80", 500),
+      adapter.readStreamEvents("thread-81", 500),
+      adapter.readLiveState("thread-0"),
+      adapter.readLiveState("thread-81"),
+    ]).then(
+      ([
+        oldestEvents,
+        secondOldestEvents,
+        newestEventsMinusOne,
+        newestEvents,
+        oldestLiveState,
+        newestLiveState,
+      ]) => {
+        expect(oldestEvents.events).toEqual([]);
+        expect(secondOldestEvents.events).toEqual([]);
+        expect(newestEventsMinusOne.events).toHaveLength(1);
+        expect(newestEvents.events).toHaveLength(1);
+        expect(oldestLiveState.conversationState).toBeNull();
+        expect(newestLiveState.conversationState?.id).toBe("thread-81");
+        expect(newestLiveState.conversationState?.title).toBe("Thread 81");
+      },
+    );
   });
 
   it("truncates buffered stream events per thread to the configured cap", async () => {
-    const adapter = createAdapterForTest() as unknown as {
-      setTrackedThreadEvents: (threadId: string, events: IpcFrame[]) => void;
-      getTrackedThreadRuntimeCounts: CodexAgentAdapter["getTrackedThreadRuntimeCounts"];
-      readStreamEvents: CodexAgentAdapter["readStreamEvents"];
-    };
+    const adapter = createAdapterForTest();
     const events: IpcFrame[] = Array.from({ length: 160 }, (_, index) => ({
       type: "broadcast",
       method: "thread-stream-state-changed",
@@ -607,11 +667,7 @@ describe("CodexAgentAdapter runtime retention", () => {
   });
 
   it("increments the parse failure counter only for malformed stream-state frames", async () => {
-    const adapter = createAdapterForTest() as unknown as {
-      setTrackedThreadEvents: (threadId: string, events: IpcFrame[]) => void;
-      getTrackedThreadRuntimeCounts: CodexAgentAdapter["getTrackedThreadRuntimeCounts"];
-      readLiveState: CodexAgentAdapter["readLiveState"];
-    };
+    const adapter = createAdapterForTest();
 
     adapter.setTrackedThreadEvents("thread-parse", [
       {
@@ -650,13 +706,7 @@ describe("CodexAgentAdapter runtime retention", () => {
   });
 
   it("restores full archived live state after a metadata-only archived read", async () => {
-    const adapter = createAdapterForTest() as unknown as {
-      restoreArchivedThreadState: (
-        threadId: string,
-        includeTurns: boolean,
-      ) => Promise<ThreadConversationState | null>;
-      readLiveState: CodexAgentAdapter["readLiveState"];
-    };
+    const adapter = createAdapterForTest();
     const threadId = "thread-archived-live-state";
     const previousCodexHome = process.env["CODEX_HOME"];
     const temporaryCodexHome = await mkdtemp(
@@ -734,15 +784,7 @@ describe("CodexAgentAdapter runtime retention", () => {
   });
 
   it("clears runtime lastError after archived readThread fallback succeeds", async () => {
-    const adapter = createAdapterForTest() as unknown as {
-      appClient: {
-        readThread: (threadId: string, includeTurns: boolean) => Promise<never>;
-        resumeThread: (threadId: string) => Promise<never>;
-      };
-      patchRuntimeState: (next: Partial<{ lastError: string | null }>) => void;
-      getRuntimeState: CodexAgentAdapter["getRuntimeState"];
-      readThread: CodexAgentAdapter["readThread"];
-    };
+    const adapter = createAdapterForTest();
     const threadId = "thread-archived-read-thread";
     const previousCodexHome = process.env["CODEX_HOME"];
     const temporaryCodexHome = await mkdtemp(
@@ -801,10 +843,10 @@ describe("CodexAgentAdapter runtime retention", () => {
       adapter.patchRuntimeState({
         lastError: noRolloutError.message,
       });
-      adapter.appClient.readThread = async () => {
+      adapter.appClientForTest.readThread = async () => {
         throw noRolloutError;
       };
-      adapter.appClient.resumeThread = async () => {
+      adapter.appClientForTest.resumeThread = async () => {
         throw noRolloutError;
       };
 

--- a/apps/server/test/codex-agent-live-state.test.ts
+++ b/apps/server/test/codex-agent-live-state.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AppServerRpcError, type AppServerClient } from "@farfield/api";
 import type {
   IpcFrame,
@@ -844,20 +844,25 @@ describe("CodexAgentAdapter runtime retention", () => {
       adapter.patchRuntimeState({
         lastError: noRolloutError.message,
       });
-      adapter.appClientForTest.readThread = async () => {
-        throw noRolloutError;
-      };
-      adapter.appClientForTest.resumeThread = async () => {
-        throw noRolloutError;
-      };
+      const readThreadSpy = vi
+        .spyOn(adapter.appClientForTest, "readThread")
+        .mockRejectedValue(noRolloutError);
+      const resumeThreadSpy = vi
+        .spyOn(adapter.appClientForTest, "resumeThread")
+        .mockRejectedValue(noRolloutError);
 
-      const result = await adapter.readThread({
-        threadId,
-        includeTurns: true,
-      });
+      try {
+        const result = await adapter.readThread({
+          threadId,
+          includeTurns: true,
+        });
 
-      expect(result.thread.turns).toHaveLength(1);
-      expect(adapter.getRuntimeState().lastError).toBeNull();
+        expect(result.thread.turns).toHaveLength(1);
+        expect(adapter.getRuntimeState().lastError).toBeNull();
+      } finally {
+        readThreadSpy.mockRestore();
+        resumeThreadSpy.mockRestore();
+      }
     } finally {
       if (previousCodexHome === undefined) {
         delete process.env["CODEX_HOME"];
@@ -910,19 +915,23 @@ describe("CodexAgentAdapter runtime retention", () => {
       adapter.patchRuntimeState({
         lastError: null,
       });
-      adapter.appClientForTest.readThread = async () => {
-        throw transportError;
-      };
+      const readThreadSpy = vi
+        .spyOn(adapter.appClientForTest, "readThread")
+        .mockRejectedValue(transportError);
 
-      await expect(
-        adapter.readThread({
-          threadId,
-          includeTurns: true,
-        }),
-      ).rejects.toThrow("app-server transport unavailable");
-      expect(adapter.getRuntimeState().lastError).toBe(
-        "app-server transport unavailable",
-      );
+      try {
+        await expect(
+          adapter.readThread({
+            threadId,
+            includeTurns: true,
+          }),
+        ).rejects.toThrow("app-server transport unavailable");
+        expect(adapter.getRuntimeState().lastError).toBe(
+          "app-server transport unavailable",
+        );
+      } finally {
+        readThreadSpy.mockRestore();
+      }
     } finally {
       if (previousCodexHome === undefined) {
         delete process.env["CODEX_HOME"];

--- a/apps/server/test/codex-agent-live-state.test.ts
+++ b/apps/server/test/codex-agent-live-state.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import type { AppServerClient } from "@farfield/api";
+import { AppServerRpcError, type AppServerClient } from "@farfield/api";
 import type {
   IpcFrame,
   ThreadConversationState,
@@ -827,7 +827,8 @@ describe("CodexAgentAdapter runtime retention", () => {
         },
       }),
     ].join("\n");
-    const noRolloutError = new Error(
+    const noRolloutError = new AppServerRpcError(
+      -32600,
       `app-server error -32600: no rollout found for thread id ${threadId}`,
     );
 
@@ -857,6 +858,114 @@ describe("CodexAgentAdapter runtime retention", () => {
 
       expect(result.thread.turns).toHaveLength(1);
       expect(adapter.getRuntimeState().lastError).toBeNull();
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env["CODEX_HOME"];
+      } else {
+        process.env["CODEX_HOME"] = previousCodexHome;
+      }
+      await rm(temporaryCodexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves unrelated readThread errors even when an archived copy exists", async () => {
+    const adapter = createAdapterForTest();
+    const threadId = "thread-read-thread-transport-error";
+    const previousCodexHome = process.env["CODEX_HOME"];
+    const temporaryCodexHome = await mkdtemp(
+      path.join(os.tmpdir(), "farfield-codex-home-"),
+    );
+    const archivedSessionsDir = path.join(temporaryCodexHome, "archived_sessions");
+    const archivedJsonl = [
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:10.772Z",
+        type: "session_meta",
+        payload: {
+          type: "session_meta",
+          id: threadId,
+          cwd: "C:\\repo",
+          source: "vscode",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.000Z",
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "archived copy should stay unused",
+        },
+      }),
+    ].join("\n");
+    const transportError = new Error("app-server transport unavailable");
+
+    try {
+      process.env["CODEX_HOME"] = temporaryCodexHome;
+      await mkdir(archivedSessionsDir, { recursive: true });
+      await writeFile(
+        path.join(archivedSessionsDir, `${threadId}.jsonl`),
+        archivedJsonl,
+        "utf8",
+      );
+
+      adapter.patchRuntimeState({
+        lastError: null,
+      });
+      adapter.appClientForTest.readThread = async () => {
+        throw transportError;
+      };
+
+      await expect(
+        adapter.readThread({
+          threadId,
+          includeTurns: true,
+        }),
+      ).rejects.toThrow("app-server transport unavailable");
+      expect(adapter.getRuntimeState().lastError).toBe(
+        "app-server transport unavailable",
+      );
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env["CODEX_HOME"];
+      } else {
+        process.env["CODEX_HOME"] = previousCodexHome;
+      }
+      await rm(temporaryCodexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not match archived rollout files by thread id substring", async () => {
+    const adapter = createAdapterForTest();
+    const previousCodexHome = process.env["CODEX_HOME"];
+    const temporaryCodexHome = await mkdtemp(
+      path.join(os.tmpdir(), "farfield-codex-home-"),
+    );
+    const archivedSessionsDir = path.join(temporaryCodexHome, "archived_sessions");
+    const requestedThreadId = "thread-1";
+    const otherThreadId = "thread-12";
+
+    try {
+      process.env["CODEX_HOME"] = temporaryCodexHome;
+      await mkdir(archivedSessionsDir, { recursive: true });
+      await writeFile(
+        path.join(archivedSessionsDir, `${otherThreadId}.jsonl`),
+        [
+          JSON.stringify({
+            timestamp: "2026-03-19T10:41:10.772Z",
+            type: "session_meta",
+            payload: {
+              type: "session_meta",
+              id: otherThreadId,
+              cwd: "C:\\repo",
+              source: "vscode",
+            },
+          }),
+        ].join("\n"),
+        "utf8",
+      );
+
+      await expect(
+        adapter.restoreArchivedThreadState(requestedThreadId, true),
+      ).resolves.toBeNull();
     } finally {
       if (previousCodexHome === undefined) {
         delete process.env["CODEX_HOME"];

--- a/apps/server/test/codex-agent-live-state.test.ts
+++ b/apps/server/test/codex-agent-live-state.test.ts
@@ -1,0 +1,827 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type {
+  IpcFrame,
+  ThreadConversationState,
+  ThreadStreamStateChangedBroadcast,
+} from "@farfield/protocol";
+import {
+  CodexAgentAdapter,
+  buildArchivedThreadConversationStateFromJsonl,
+  collectThreadStreamStateChangedEvents,
+} from "../src/agents/adapters/codex-agent.js";
+
+const SAMPLE_THREAD_STATE: ThreadConversationState = {
+  id: "thread-1",
+  turns: [],
+  requests: [],
+  createdAt: 1700000000,
+  updatedAt: 1700000100,
+  title: "Thread",
+  latestModel: null,
+  latestReasoningEffort: null,
+};
+
+function buildSnapshotEvent(): ThreadStreamStateChangedBroadcast {
+  return {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "owner-1",
+    version: 1,
+    params: {
+      conversationId: "thread-1",
+      change: {
+        type: "snapshot",
+        conversationState: SAMPLE_THREAD_STATE,
+      },
+      version: 1,
+      type: "thread-stream-state-changed",
+    },
+  };
+}
+
+describe("collectThreadStreamStateChangedEvents", () => {
+  it("ignores unrelated thread broadcast frames", () => {
+    const archivedEvent: IpcFrame = {
+      type: "broadcast",
+      method: "thread-archived",
+      sourceClientId: "owner-1",
+      version: 2,
+      params: {
+        conversationId: "thread-1",
+        hostId: "local",
+        cwd: "C:\\repo",
+      },
+    };
+
+    const result = collectThreadStreamStateChangedEvents([
+      buildSnapshotEvent(),
+      archivedEvent,
+    ]);
+
+    expect(result.parseError).toBeNull();
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.params.conversationId).toBe("thread-1");
+  });
+
+  it("still reports malformed thread-stream-state-changed frames", () => {
+    const malformedEvent: IpcFrame = {
+      type: "broadcast",
+      method: "thread-stream-state-changed",
+      sourceClientId: "owner-1",
+      version: 1,
+      params: {
+        conversationId: "thread-1",
+      },
+    };
+
+    const result = collectThreadStreamStateChangedEvents([malformedEvent]);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.parseError?.eventIndex).toBe(0);
+    expect(result.parseError?.message).toContain("params.change");
+  });
+});
+
+describe("buildArchivedThreadConversationStateFromJsonl", () => {
+  it("rebuilds a minimal thread state from archived rollout events", () => {
+    const jsonl = [
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:10.772Z",
+        type: "session_meta",
+        payload: {
+          type: "session_meta",
+          id: "thread-archive-1",
+          cwd: "C:\\repo",
+          source: "vscode",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:22.961Z",
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: "turn-1",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:22.962Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "hello",
+          images: ["https://example.com/image.png"],
+          local_images: [],
+          text_elements: [],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.000Z",
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "working on it",
+          phase: "commentary",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.100Z",
+        type: "event_msg",
+        payload: {
+          type: "reasoning",
+          summary: ["check logs"],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.200Z",
+        type: "event_msg",
+        payload: {
+          type: "context_compacted",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.300Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 1,
+              output_tokens: 2,
+              total_tokens: 3,
+            },
+          },
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.400Z",
+        type: "event_msg",
+        payload: {
+          type: "task_complete",
+          turn_id: "turn-1",
+        },
+      }),
+    ].join("\n");
+
+    const result = buildArchivedThreadConversationStateFromJsonl(
+      jsonl,
+      "thread-archive-1",
+      {
+        title: "Archived thread",
+        updatedAt: 1710844883,
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.title).toBe("Archived thread");
+    expect(result?.cwd).toBe("C:\\repo");
+    expect(result?.source).toBe("vscode");
+    expect(result?.turns).toHaveLength(1);
+    expect(result?.turns[0]?.turnId).toBe("turn-1");
+    expect(result?.turns[0]?.status).toBe("completed");
+    expect(result?.turns[0]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "userMessage" }),
+        expect.objectContaining({ type: "agentMessage", text: "working on it" }),
+        expect.objectContaining({ type: "reasoning", summary: ["check logs"] }),
+        expect.objectContaining({ type: "contextCompaction" }),
+      ]),
+    );
+    expect(result?.latestTokenUsageInfo).toEqual({
+      total_token_usage: {
+        input_tokens: 1,
+        output_tokens: 2,
+        total_tokens: 3,
+      },
+    });
+  });
+
+  it("rebuilds legacy tool payloads into bounded dynamic tool items", () => {
+    const longOutput = "x".repeat(400);
+    const jsonl = [
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:00.000Z",
+        type: "session_meta",
+        payload: {
+          type: "session_meta",
+          id: "thread-archive-tools",
+          cwd: "C:\\repo",
+          source: "vscode",
+          model: "gpt-5.3-codex",
+          reasoning_effort: "high",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:01.000Z",
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: "turn-tools-1",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:01.100Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "developer",
+          content: [
+            {
+              type: "input_text",
+              text: "Follow the runtime hardening checklist.",
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:01.200Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [
+            {
+              type: "output_text",
+              text: "Inspecting archived replay coverage now.",
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "shell_command",
+          arguments: JSON.stringify({
+            command: "Get-ChildItem",
+            workdir: "C:\\repo",
+          }),
+          call_id: "call-function-1",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:03.000Z",
+        type: "response_item",
+        payload: {
+          type: "function_call_output",
+          call_id: "call-function-1",
+          output: {
+            body: longOutput,
+            success: true,
+          },
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:04.000Z",
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: "call-custom-1",
+          name: "ask_user",
+          input: "Need confirmation",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:05.000Z",
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call_output",
+          call_id: "call-custom-1",
+          output: {
+            body: [
+              {
+                type: "input_text",
+                text: "Confirmed by user",
+              },
+            ],
+            success: false,
+          },
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:06.000Z",
+        type: "event_msg",
+        payload: {
+          type: "dynamic_tool_call_request",
+          callId: "call-dynamic-1",
+          turnId: "turn-tools-1",
+          tool: "generate_image",
+          arguments: {
+            prompt: "render an architecture diagram",
+          },
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:07.000Z",
+        type: "event_msg",
+        payload: {
+          type: "dynamic_tool_call_response",
+          call_id: "call-dynamic-1",
+          turn_id: "turn-tools-1",
+          tool: "generate_image",
+          arguments: {
+            prompt: "render an architecture diagram",
+          },
+          content_items: [
+            {
+              type: "input_image",
+              image_url: "https://example.com/diagram.png",
+            },
+          ],
+          success: true,
+          error: null,
+          duration: "PT1.25S",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:08.000Z",
+        type: "event_msg",
+        payload: {
+          type: "todo_list",
+          explanation: null,
+          plan: [
+            {
+              step: "Verify archived replay",
+              status: "completed",
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:08.250Z",
+        type: "response_item",
+        payload: {
+          type: "web_search_call",
+          status: "completed",
+          action: {
+            type: "search",
+            query: "time: {\"utc_offset\":\"+08:00\"}",
+            queries: ['time: {"utc_offset":"+08:00"}'],
+          },
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:08.500Z",
+        type: "event_msg",
+        payload: {
+          type: "unknown_future_payload",
+          extra: true,
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-20T14:40:09.000Z",
+        type: "event_msg",
+        payload: {
+          type: "task_complete",
+          turn_id: "turn-tools-1",
+        },
+      }),
+    ].join("\n");
+
+    const result = buildArchivedThreadConversationStateFromJsonl(
+      jsonl,
+      "thread-archive-tools",
+      {
+        title: "Archived tools",
+        updatedAt: 1710844883,
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.latestModel).toBe("gpt-5.3-codex");
+    expect(result?.latestReasoningEffort).toBe("high");
+
+    const toolItems =
+      result?.turns[0]?.items.filter(
+        (item): item is Extract<typeof item, { type: "dynamicToolCall" }> =>
+          item.type === "dynamicToolCall",
+      ) ?? [];
+    expect(toolItems).toHaveLength(4);
+    expect(toolItems[0]).toEqual(
+      expect.objectContaining({
+        type: "dynamicToolCall",
+        tool: "shell_command",
+        status: "completed",
+        success: true,
+      }),
+    );
+    expect(
+      toolItems[0]?.contentItems?.[0]?.type === "inputText"
+        ? toolItems[0].contentItems[0].text.length
+        : 0,
+    ).toBeLessThanOrEqual(243);
+    expect(toolItems[1]).toEqual(
+      expect.objectContaining({
+        tool: "ask_user",
+        status: "failed",
+        success: false,
+      }),
+    );
+    expect(toolItems[2]).toEqual(
+      expect.objectContaining({
+        tool: "generate_image",
+        status: "completed",
+        success: true,
+        durationMs: 1250,
+      }),
+    );
+    expect(toolItems[2]?.contentItems?.[0]).toEqual({
+      type: "inputImage",
+      imageUrl: "https://example.com/diagram.png",
+    });
+    expect(toolItems[3]).toEqual(
+      expect.objectContaining({
+        tool: "web_search",
+        status: "completed",
+      }),
+    );
+    expect(toolItems[3]?.contentItems).toEqual([
+      {
+        type: "inputText",
+        text: 'time: {"utc_offset":"+08:00"}',
+      },
+    ]);
+
+    expect(result?.turns[0]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "steeringUserMessage",
+        }),
+        expect.objectContaining({
+          type: "agentMessage",
+          text: "Inspecting archived replay coverage now.",
+          phase: "commentary",
+        }),
+      ]),
+    );
+
+    const todoItem = result?.turns[0]?.items.find(
+      (item) => item.type === "todoList",
+    );
+    expect(todoItem).toEqual(
+      expect.objectContaining({
+        type: "todoList",
+        plan: [
+          {
+            step: "Verify archived replay",
+            status: "completed",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("skips malformed trailing jsonl lines and restores earlier archived entries", () => {
+    const jsonl = [
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:10.772Z",
+        type: "session_meta",
+        payload: {
+          type: "session_meta",
+          id: "thread-archive-tail",
+          cwd: "C:\\repo",
+          source: "vscode",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:22.961Z",
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: "turn-tail-1",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:22.962Z",
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "still restorable",
+        },
+      }),
+      '{"timestamp":"2026-03-19T10:41:23.000Z","payload":',
+    ].join("\n");
+
+    const result = buildArchivedThreadConversationStateFromJsonl(
+      jsonl,
+      "thread-archive-tail",
+      null,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.turns).toHaveLength(1);
+    expect(result?.turns[0]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "agentMessage",
+          text: "still restorable",
+        }),
+      ]),
+    );
+  });
+});
+
+describe("CodexAgentAdapter runtime retention", () => {
+  function createAdapterForTest(): CodexAgentAdapter {
+    return new CodexAgentAdapter({
+      appExecutable: "codex",
+      socketPath: "\\\\.\\pipe\\farfield-test",
+      workspaceDir: process.cwd(),
+      userAgent: "farfield-test",
+      reconnectDelayMs: 1,
+    });
+  }
+
+  it("evicts the oldest tracked thread state after the runtime cap", () => {
+    const adapter = createAdapterForTest() as unknown as {
+      setTrackedThreadOwner: (threadId: string, ownerClientId: string) => void;
+      setTrackedThreadSnapshot: (
+        threadId: string,
+        snapshot: ThreadConversationState,
+        origin: "stream" | "readThreadWithTurns" | "readThread",
+      ) => void;
+      setTrackedThreadEvents: (threadId: string, events: IpcFrame[]) => void;
+      setThreadTitle: (threadId: string, title: string | null) => void;
+      getTrackedThreadRuntimeCounts: CodexAgentAdapter["getTrackedThreadRuntimeCounts"];
+      readStreamEvents: CodexAgentAdapter["readStreamEvents"];
+    };
+
+    for (let index = 0; index < 82; index += 1) {
+      const threadId = `thread-${String(index)}`;
+      adapter.setTrackedThreadOwner(threadId, `owner-${String(index)}`);
+      adapter.setTrackedThreadSnapshot(
+        threadId,
+        {
+          ...SAMPLE_THREAD_STATE,
+          id: threadId,
+          title: `Thread ${String(index)}`,
+        },
+        "stream",
+      );
+      adapter.setTrackedThreadEvents(threadId, [buildSnapshotEvent()]);
+      adapter.setThreadTitle(threadId, `Thread ${String(index)}`);
+    }
+
+    const counts = adapter.getTrackedThreadRuntimeCounts();
+    expect(counts.trackedThreadCount).toBe(80);
+    expect(counts.maxTrackedThreadCountSeen).toBe(80);
+    expect(counts.streamEventThreadCount).toBe(80);
+  });
+
+  it("truncates buffered stream events per thread to the configured cap", async () => {
+    const adapter = createAdapterForTest() as unknown as {
+      setTrackedThreadEvents: (threadId: string, events: IpcFrame[]) => void;
+      getTrackedThreadRuntimeCounts: CodexAgentAdapter["getTrackedThreadRuntimeCounts"];
+      readStreamEvents: CodexAgentAdapter["readStreamEvents"];
+    };
+    const events: IpcFrame[] = Array.from({ length: 160 }, (_, index) => ({
+      type: "broadcast",
+      method: "thread-stream-state-changed",
+      sourceClientId: "owner-1",
+      version: 1,
+      params: {
+        conversationId: "thread-cap",
+        change: {
+          type: "snapshot",
+          conversationState: {
+            ...SAMPLE_THREAD_STATE,
+            id: `thread-cap-${String(index)}`,
+          },
+        },
+        version: 1,
+        type: "thread-stream-state-changed",
+      },
+    }));
+
+    adapter.setTrackedThreadEvents("thread-cap", events);
+
+    const stream = await adapter.readStreamEvents("thread-cap", 500);
+    expect(stream.events).toHaveLength(120);
+    expect(adapter.getTrackedThreadRuntimeCounts().maxBufferedStreamEventsPerThreadSeen).toBe(
+      120,
+    );
+  });
+
+  it("increments the parse failure counter only for malformed stream-state frames", async () => {
+    const adapter = createAdapterForTest() as unknown as {
+      setTrackedThreadEvents: (threadId: string, events: IpcFrame[]) => void;
+      getTrackedThreadRuntimeCounts: CodexAgentAdapter["getTrackedThreadRuntimeCounts"];
+      readLiveState: CodexAgentAdapter["readLiveState"];
+    };
+
+    adapter.setTrackedThreadEvents("thread-parse", [
+      {
+        type: "broadcast",
+        method: "thread-archived",
+        sourceClientId: "owner-1",
+        version: 1,
+        params: {
+          conversationId: "thread-parse",
+        },
+      },
+    ]);
+
+    await adapter.readLiveState("thread-parse");
+    expect(adapter.getTrackedThreadRuntimeCounts().streamParseFailureCount).toBe(
+      0,
+    );
+
+    adapter.setTrackedThreadEvents("thread-parse", [
+      {
+        type: "broadcast",
+        method: "thread-stream-state-changed",
+        sourceClientId: "owner-1",
+        version: 1,
+        params: {
+          conversationId: "thread-parse",
+        },
+      },
+    ]);
+
+    const result = await adapter.readLiveState("thread-parse");
+    expect(result.liveStateError?.kind).toBe("parseFailed");
+    expect(adapter.getTrackedThreadRuntimeCounts().streamParseFailureCount).toBe(
+      1,
+    );
+  });
+
+  it("restores full archived live state after a metadata-only archived read", async () => {
+    const adapter = createAdapterForTest() as unknown as {
+      restoreArchivedThreadState: (
+        threadId: string,
+        includeTurns: boolean,
+      ) => Promise<ThreadConversationState | null>;
+      readLiveState: CodexAgentAdapter["readLiveState"];
+    };
+    const threadId = "thread-archived-live-state";
+    const previousCodexHome = process.env["CODEX_HOME"];
+    const temporaryCodexHome = await mkdtemp(
+      path.join(os.tmpdir(), "farfield-codex-home-"),
+    );
+    const archivedSessionsDir = path.join(temporaryCodexHome, "archived_sessions");
+    const archivedJsonl = [
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:10.772Z",
+        type: "session_meta",
+        payload: {
+          type: "session_meta",
+          id: threadId,
+          cwd: "C:\\repo",
+          source: "vscode",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:22.961Z",
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: "turn-archive-live-1",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.000Z",
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "restored from archive",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.400Z",
+        type: "event_msg",
+        payload: {
+          type: "task_complete",
+          turn_id: "turn-archive-live-1",
+        },
+      }),
+    ].join("\n");
+
+    try {
+      process.env["CODEX_HOME"] = temporaryCodexHome;
+      await mkdir(archivedSessionsDir, { recursive: true });
+      await writeFile(
+        path.join(archivedSessionsDir, `${threadId}.jsonl`),
+        archivedJsonl,
+        "utf8",
+      );
+
+      const metadataOnly = await adapter.restoreArchivedThreadState(threadId, false);
+      expect(metadataOnly?.turns).toHaveLength(0);
+
+      const liveState = await adapter.readLiveState(threadId);
+      expect(liveState.liveStateError).toBeNull();
+      expect(liveState.conversationState?.turns).toHaveLength(1);
+      expect(liveState.conversationState?.turns[0]?.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "agentMessage",
+            text: "restored from archive",
+          }),
+        ]),
+      );
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env["CODEX_HOME"];
+      } else {
+        process.env["CODEX_HOME"] = previousCodexHome;
+      }
+      await rm(temporaryCodexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("clears runtime lastError after archived readThread fallback succeeds", async () => {
+    const adapter = createAdapterForTest() as unknown as {
+      appClient: {
+        readThread: (threadId: string, includeTurns: boolean) => Promise<never>;
+        resumeThread: (threadId: string) => Promise<never>;
+      };
+      patchRuntimeState: (next: Partial<{ lastError: string | null }>) => void;
+      getRuntimeState: CodexAgentAdapter["getRuntimeState"];
+      readThread: CodexAgentAdapter["readThread"];
+    };
+    const threadId = "thread-archived-read-thread";
+    const previousCodexHome = process.env["CODEX_HOME"];
+    const temporaryCodexHome = await mkdtemp(
+      path.join(os.tmpdir(), "farfield-codex-home-"),
+    );
+    const archivedSessionsDir = path.join(temporaryCodexHome, "archived_sessions");
+    const archivedJsonl = [
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:10.772Z",
+        type: "session_meta",
+        payload: {
+          type: "session_meta",
+          id: threadId,
+          cwd: "C:\\repo",
+          source: "vscode",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:22.961Z",
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: "turn-archive-read-1",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.000Z",
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "fallback restored thread",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-19T10:41:23.400Z",
+        type: "event_msg",
+        payload: {
+          type: "task_complete",
+          turn_id: "turn-archive-read-1",
+        },
+      }),
+    ].join("\n");
+    const noRolloutError = new Error(
+      `app-server error -32600: no rollout found for thread id ${threadId}`,
+    );
+
+    try {
+      process.env["CODEX_HOME"] = temporaryCodexHome;
+      await mkdir(archivedSessionsDir, { recursive: true });
+      await writeFile(
+        path.join(archivedSessionsDir, `${threadId}.jsonl`),
+        archivedJsonl,
+        "utf8",
+      );
+
+      adapter.patchRuntimeState({
+        lastError: noRolloutError.message,
+      });
+      adapter.appClient.readThread = async () => {
+        throw noRolloutError;
+      };
+      adapter.appClient.resumeThread = async () => {
+        throw noRolloutError;
+      };
+
+      const result = await adapter.readThread({
+        threadId,
+        includeTurns: true,
+      });
+
+      expect(result.thread.turns).toHaveLength(1);
+      expect(adapter.getRuntimeState().lastError).toBeNull();
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env["CODEX_HOME"];
+      } else {
+        process.env["CODEX_HOME"] = previousCodexHome;
+      }
+      await rm(temporaryCodexHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/test/debug-history.test.ts
+++ b/apps/server/test/debug-history.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { prepareHistoryPayloadForStorage } from "../src/debug-history.js";
+
+describe("prepareHistoryPayloadForStorage", () => {
+  it("preserves small payloads without compaction", () => {
+    const result = prepareHistoryPayloadForStorage({
+      type: "broadcast",
+      method: "ping",
+      params: { ok: true },
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(JSON.parse(result.json)).toEqual({
+      type: "broadcast",
+      method: "ping",
+      params: { ok: true },
+    });
+  });
+
+  it("compacts thread-stream snapshots while keeping debug-critical fields", () => {
+    const largeText = "x".repeat(2_000);
+    const result = prepareHistoryPayloadForStorage({
+      type: "broadcast",
+      method: "thread-stream-state-changed",
+      params: {
+        conversationId: "thread-123",
+        change: {
+          type: "snapshot",
+          conversationState: {
+            id: "thread-123",
+            turns: [
+              {
+                turnId: "turn-1",
+                status: "completed",
+                items: [
+                  {
+                    id: "item-1",
+                    type: "userMessage",
+                    content: [{ type: "text", text: largeText }],
+                  },
+                  {
+                    id: "item-2",
+                    type: "agentMessage",
+                    phase: "commentary",
+                    text: largeText,
+                  },
+                  {
+                    id: "item-3",
+                    type: "contextCompaction",
+                  },
+                ],
+              },
+            ],
+            requests: [],
+          },
+        },
+      },
+    });
+
+    const stored = JSON.parse(result.json);
+    const turn = stored.params.change.conversationState.turns[0];
+
+    expect(result.compacted).toBe(true);
+    expect(turn.turnId).toBe("turn-1");
+    expect(turn.itemCount).toBe(3);
+    expect(turn.itemTypes).toEqual([
+      "userMessage",
+      "agentMessage",
+      "contextCompaction",
+    ]);
+    expect(turn.items[1]).toMatchObject({
+      id: "item-2",
+      type: "agentMessage",
+      phase: "commentary",
+    });
+    expect(turn.items[1].text).toContain("... [");
+  });
+
+  it("compacts thread-stream patches into a bounded preview", () => {
+    const result = prepareHistoryPayloadForStorage({
+      type: "broadcast",
+      method: "thread-stream-state-changed",
+      params: {
+        conversationId: "thread-456",
+        change: {
+          type: "patches",
+          patches: Array.from({ length: 40 }, (_, index) => ({
+            op: "add",
+            path: ["turns", 0, "items", index],
+            value: {
+              id: `item-${index}`,
+              type: "agentMessage",
+              text: "y".repeat(1_000),
+            },
+          })),
+        },
+      },
+    });
+
+    const stored = JSON.parse(result.json);
+    expect(result.compacted).toBe(true);
+    expect(stored.params.change.patchCount).toBe(40);
+    expect(stored.params.change.patches).toHaveLength(24);
+    expect(stored.params.change.truncatedPatchCount).toBe(16);
+  });
+
+  it("handles BigInt and undefined roots without throwing", () => {
+    const bigintResult = prepareHistoryPayloadForStorage({
+      type: "system",
+      value: 42n,
+    });
+    const undefinedResult = prepareHistoryPayloadForStorage(undefined);
+
+    expect(JSON.parse(bigintResult.json)).toEqual({
+      type: "system",
+      value: "42",
+    });
+    expect(undefinedResult.json).toBe("null");
+  });
+
+  it("falls back safely when payload contains circular references", () => {
+    const payload: { type: string; self?: unknown } = {
+      type: "system",
+    };
+    payload.self = payload;
+
+    const result = prepareHistoryPayloadForStorage(payload);
+
+    expect(JSON.parse(result.json)).toEqual({
+      type: "system",
+      self: "[Circular]",
+    });
+  });
+
+  it("reports turnOffsetFromLatest relative to the latest retained turn", () => {
+    const result = prepareHistoryPayloadForStorage({
+      type: "broadcast",
+      method: "thread-stream-state-changed",
+      params: {
+        conversationId: "thread-offsets",
+        change: {
+          type: "snapshot",
+          conversationState: {
+            id: "thread-offsets",
+            turns: Array.from({ length: 20 }, (_, index) => ({
+              turnId: `turn-${index}`,
+              status: "completed",
+              items: [],
+            })),
+            requests: [],
+          },
+        },
+      },
+    });
+
+    const stored = JSON.parse(result.json);
+    const retainedTurns = stored.params.change.conversationState.turns;
+
+    expect(retainedTurns).toHaveLength(16);
+    expect(retainedTurns[0]?.turnId).toBe("turn-4");
+    expect(retainedTurns[0]?.turnOffsetFromLatest).toBe(15);
+    expect(retainedTurns[15]?.turnId).toBe("turn-19");
+    expect(retainedTurns[15]?.turnOffsetFromLatest).toBe(0);
+  });
+});

--- a/apps/server/test/unified-adapter.test.ts
+++ b/apps/server/test/unified-adapter.test.ts
@@ -615,4 +615,361 @@ describe("unified provider adapters", () => {
         : null,
     ).toBe("task-123");
   });
+
+  it("maps dynamicToolCall turn items into unified items", async () => {
+    const adapter = createCodexAdapter();
+    const longQuery = "x".repeat(800);
+    adapter.readThread = async () => ({
+      thread: {
+        ...SAMPLE_THREAD,
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            items: [
+              {
+                id: "item-dynamic",
+                type: "dynamicToolCall",
+                tool: "web_search",
+                status: "completed",
+                arguments: {
+                  query: longQuery,
+                },
+                contentItems: [
+                  {
+                    type: "inputText",
+                    text: "Search complete",
+                  },
+                  {
+                    type: "inputImage",
+                    imageUrl: "https://example.com/result.png",
+                  },
+                ],
+                success: true,
+                durationMs: 64,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const unified = new AgentUnifiedProviderAdapter("codex", adapter);
+
+    const result = await unified.execute(
+      UnifiedCommandSchema.parse({
+        kind: "readThread",
+        provider: "codex",
+        threadId: SAMPLE_THREAD.id,
+        includeTurns: true,
+      }),
+    );
+
+    expect(result.kind).toBe("readThread");
+    if (result.kind !== "readThread") {
+      return;
+    }
+
+    const dynamicItem = result.thread.turns[0]?.items[0];
+    expect(dynamicItem?.type).toBe("dynamicToolCall");
+    expect(
+      dynamicItem && dynamicItem.type === "dynamicToolCall"
+        ? dynamicItem.tool
+        : null,
+    ).toBe("web_search");
+    expect(
+      dynamicItem && dynamicItem.type === "dynamicToolCall"
+        ? dynamicItem.contentItems?.length
+        : null,
+    ).toBe(2);
+    expect(
+      dynamicItem && dynamicItem.type === "dynamicToolCall"
+        ? dynamicItem.success
+        : null,
+    ).toBe(true);
+    expect(
+      dynamicItem && dynamicItem.type === "dynamicToolCall"
+        ? typeof dynamicItem.arguments
+        : null,
+    ).toBe("string");
+    expect(
+      dynamicItem && dynamicItem.type === "dynamicToolCall"
+        ? String(dynamicItem.arguments).length
+        : 0,
+    ).toBeLessThanOrEqual(603);
+  });
+
+  it("maps mcpToolCall items into lightweight unified previews", async () => {
+    const adapter = createCodexAdapter();
+    const largeText = "y".repeat(800);
+    adapter.readThread = async () => ({
+      thread: {
+        ...SAMPLE_THREAD,
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            items: [
+              {
+                id: "item-mcp",
+                type: "mcpToolCall",
+                server: "filesystem",
+                tool: "read_file",
+                status: "completed",
+                arguments: {
+                  path: "/tmp/huge.txt",
+                  extra: largeText,
+                },
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: largeText,
+                    },
+                    {
+                      type: "text",
+                      text: "tail",
+                    },
+                  ],
+                  structuredContent: {
+                    body: largeText,
+                  },
+                },
+                durationMs: 41,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const unified = new AgentUnifiedProviderAdapter("codex", adapter);
+
+    const result = await unified.execute(
+      UnifiedCommandSchema.parse({
+        kind: "readThread",
+        provider: "codex",
+        threadId: SAMPLE_THREAD.id,
+        includeTurns: true,
+      }),
+    );
+
+    expect(result.kind).toBe("readThread");
+    if (result.kind !== "readThread") {
+      return;
+    }
+
+    const mcpItem = result.thread.turns[0]?.items[0];
+    expect(mcpItem?.type).toBe("mcpToolCall");
+    expect(
+      mcpItem && mcpItem.type === "mcpToolCall" ? typeof mcpItem.arguments : null,
+    ).toBe("string");
+    expect(
+      mcpItem && mcpItem.type === "mcpToolCall"
+        ? String(mcpItem.arguments).length
+        : 0,
+    ).toBeLessThanOrEqual(603);
+    expect(
+      mcpItem && mcpItem.type === "mcpToolCall" ? mcpItem.result?.content : null,
+    ).toEqual([null, null]);
+    expect(
+      mcpItem && mcpItem.type === "mcpToolCall"
+        ? typeof mcpItem.result?.structuredContent
+        : null,
+    ).toBe("string");
+    expect(
+      mcpItem &&
+        mcpItem.type === "mcpToolCall" &&
+        typeof mcpItem.result?.structuredContent === "string"
+        ? mcpItem.result.structuredContent.length
+        : 0,
+    ).toBeLessThanOrEqual(603);
+  });
+
+  it("trims readThread results to the requested render window", async () => {
+    const adapter = createCodexAdapter();
+    adapter.readThread = async () => ({
+      thread: {
+        ...SAMPLE_THREAD,
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            items: Array.from({ length: 95 }, (_, index) => ({
+              id: `item-agent-${index}`,
+              type: "agentMessage",
+              text: `agent-message-${index}`,
+            })),
+          },
+        ],
+      },
+    });
+    const unified = new AgentUnifiedProviderAdapter("codex", adapter);
+
+    const result = await unified.execute(
+      UnifiedCommandSchema.parse({
+        kind: "readThread",
+        provider: "codex",
+        threadId: SAMPLE_THREAD.id,
+        includeTurns: true,
+        maxRenderableItems: 90,
+      }),
+    );
+
+    expect(result.kind).toBe("readThread");
+    if (result.kind !== "readThread") {
+      return;
+    }
+
+    expect(result.thread.turns[0]?.items.length).toBe(91);
+    const firstItem = result.thread.turns[0]?.items[0];
+    expect(firstItem?.type).toBe("agentMessage");
+    expect(
+      firstItem && firstItem.type === "agentMessage" ? firstItem.text : null,
+    ).toBe("agent-message-4");
+  });
+
+  it("counts image-only user messages when trimming readThread results", async () => {
+    const adapter = createCodexAdapter();
+    adapter.readThread = async () => ({
+      thread: {
+        ...SAMPLE_THREAD,
+        turns: [
+          {
+            id: "turn-images",
+            status: "completed",
+            items: Array.from({ length: 95 }, (_, index) => ({
+              id: `item-image-${index}`,
+              type: "userMessage",
+              content: [
+                {
+                  type: "image",
+                  url: `https://example.com/image-${index}.png`,
+                },
+              ],
+            })),
+          },
+        ],
+      },
+    });
+    const unified = new AgentUnifiedProviderAdapter("codex", adapter);
+
+    const result = await unified.execute(
+      UnifiedCommandSchema.parse({
+        kind: "readThread",
+        provider: "codex",
+        threadId: SAMPLE_THREAD.id,
+        includeTurns: true,
+        maxRenderableItems: 90,
+      }),
+    );
+
+    expect(result.kind).toBe("readThread");
+    if (result.kind !== "readThread") {
+      return;
+    }
+
+    expect(result.thread.turns[0]?.items.length).toBe(91);
+    const firstItem = result.thread.turns[0]?.items[0];
+    expect(firstItem?.type).toBe("userMessage");
+    expect(
+      firstItem && firstItem.type === "userMessage"
+        ? firstItem.content[0]?.type
+        : null,
+    ).toBe("image");
+  });
+
+  it("trims readLiveState results to the requested render window", async () => {
+    const adapter = createCodexAdapter();
+    adapter.readLiveState = async () => ({
+      ownerClientId: "owner-1",
+      conversationState: {
+        ...SAMPLE_THREAD,
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            items: Array.from({ length: 95 }, (_, index) => ({
+              id: `item-live-${index}`,
+              type: "agentMessage",
+              text: `live-message-${index}`,
+            })),
+          },
+        ],
+      },
+      liveStateError: null,
+    });
+    const unified = new AgentUnifiedProviderAdapter("codex", adapter);
+
+    const result = await unified.execute(
+      UnifiedCommandSchema.parse({
+        kind: "readLiveState",
+        provider: "codex",
+        threadId: SAMPLE_THREAD.id,
+        maxRenderableItems: 90,
+      }),
+    );
+
+    expect(result.kind).toBe("readLiveState");
+    if (result.kind !== "readLiveState") {
+      return;
+    }
+
+    expect(result.conversationState?.turns[0]?.items.length).toBe(91);
+    const firstItem = result.conversationState?.turns[0]?.items[0];
+    expect(firstItem?.type).toBe("agentMessage");
+    expect(
+      firstItem && firstItem.type === "agentMessage" ? firstItem.text : null,
+    ).toBe("live-message-4");
+  });
+
+  it("normalizes todoList live-state items with null explanation", async () => {
+    const adapter = createCodexAdapter();
+    adapter.readLiveState = async () => ({
+      ownerClientId: "owner-1",
+      conversationState: {
+        ...SAMPLE_THREAD,
+        turns: [
+          {
+            id: "turn-1",
+            status: "inProgress",
+            items: [
+              {
+                id: "item-todo",
+                type: "todoList",
+                explanation: null,
+                plan: [
+                  {
+                    step: "Verify compatibility",
+                    status: "completed",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      liveStateError: null,
+    });
+    const unified = new AgentUnifiedProviderAdapter("codex", adapter);
+
+    const result = await unified.execute(
+      UnifiedCommandSchema.parse({
+        kind: "readLiveState",
+        provider: "codex",
+        threadId: SAMPLE_THREAD.id,
+      }),
+    );
+
+    expect(result.kind).toBe("readLiveState");
+    if (result.kind !== "readLiveState") {
+      return;
+    }
+
+    const todoItem = result.conversationState?.turns[0]?.items[0];
+    expect(todoItem?.type).toBe("todoList");
+    expect(
+      todoItem && todoItem.type === "todoList"
+        ? Object.prototype.hasOwnProperty.call(todoItem, "explanation")
+        : null,
+    ).toBe(false);
+  });
 });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -16,6 +16,7 @@
       content="#09090b"
       media="(prefers-color-scheme: dark)"
     />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script>
       (() => {
         try {

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#0f172a" />
+  <path
+    d="M18 18h28v8H27v8h16v8H27v14h-9V18Zm24 16h4c6.627 0 12 5.373 12 12v10h-9V46a3 3 0 0 0-3-3h-4v-9Z"
+    fill="#f8fafc"
+  />
+</svg>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1127,7 +1127,25 @@ function basenameFromPath(value: string): string {
 }
 
 function displayPathFromValue(value: string): string {
-  return value.trim().replaceAll("\\", "/").replace(/\/+/g, "/").replace(/\/+$/, "");
+  const normalizedSlashes = value.trim().replaceAll("\\", "/");
+  if (normalizedSlashes.length === 0) {
+    return "";
+  }
+
+  const collapsed = normalizedSlashes.startsWith("//")
+    ? `//${normalizedSlashes.replace(/^\/+/, "").replace(/\/+/g, "/")}`
+    : normalizedSlashes.replace(/\/+/g, "/");
+  if (
+    collapsed === "/" ||
+    /^[a-z]:\/$/i.test(collapsed) ||
+    /^\/\/[^/]+\/[^/]+\/?$/i.test(collapsed)
+  ) {
+    return collapsed === "/" || collapsed.endsWith("/")
+      ? collapsed
+      : `${collapsed}/`;
+  }
+
+  return collapsed.replace(/\/+$/, "");
 }
 
 function normalizeProjectPathKey(value: string): string {
@@ -1477,7 +1495,10 @@ export function App(): React.JSX.Element {
   const [draggedGroupKey, setDraggedGroupKey] = useState<string | null>(null);
 
   /* Refs */
-  const selectedThreadIdRef = useRef<string | null>(null);
+  const selectedThreadIdRef = useRef<string | null>(
+    initialSnapshot?.selectedThreadId ?? initialUiState.threadId,
+  );
+  const selectedThreadRevisionRef = useRef(0);
   const visibleChatItemLimitRef = useRef(INITIAL_VISIBLE_CHAT_ITEMS);
   const activeTabRef = useRef<"chat" | "debug">(
     initialTab,
@@ -1529,6 +1550,25 @@ export function App(): React.JSX.Element {
   const modelsSignatureRef = useRef<string[]>([]);
   const historyDetailCacheRef = useRef<Map<string, HistoryDetail>>(new Map());
   const historyDetailRequestIdRef = useRef(0);
+
+  const updateSelectedThreadId = useCallback(
+    (
+      next:
+        | string
+        | null
+        | ((current: string | null) => string | null),
+    ) => {
+      const current = selectedThreadIdRef.current;
+      const resolved = typeof next === "function" ? next(current) : next;
+      if (resolved === current) {
+        return;
+      }
+      selectedThreadIdRef.current = resolved;
+      selectedThreadRevisionRef.current += 1;
+      setSelectedThreadId(resolved);
+    },
+    [],
+  );
 
   /* Derived */
   const selectedThread = useMemo(
@@ -1638,9 +1678,15 @@ export function App(): React.JSX.Element {
         threadAgentId,
       );
 
+      const nextIsHistoricalOnly =
+        projectKey.length > 0 &&
+        currentProjectPathKeys !== undefined &&
+        !currentProjectPathKeys.has(projectKey);
       const existing = groups.get(key);
       if (existing) {
         existing.threads.push(thread);
+        existing.isHistoricalOnly =
+          existing.isHistoricalOnly && nextIsHistoricalOnly;
         if (!existing.preferredAgentId) {
           existing.preferredAgentId = threadAgentId;
         }
@@ -1653,10 +1699,7 @@ export function App(): React.JSX.Element {
           label,
           projectPath,
           pathHint: projectPath ? projectPathHint(projectPath) : null,
-          isHistoricalOnly:
-            projectKey.length > 0 &&
-            currentProjectPathKeys !== undefined &&
-            !currentProjectPathKeys.has(projectKey),
+          isHistoricalOnly: nextIsHistoricalOnly,
           latestUpdatedAt: updatedAt,
           preferredAgentId: threadAgentId,
           threads: [thread],
@@ -2073,11 +2116,11 @@ export function App(): React.JSX.Element {
       if (window.location.pathname !== nextPath) {
         window.history.pushState(null, "", nextPath);
       }
-      setSelectedThreadId(threadId);
+      updateSelectedThreadId(threadId);
       setActiveTab("chat");
       closeMobileSidebar();
     },
-    [closeMobileSidebar],
+    [closeMobileSidebar, updateSelectedThreadId],
   );
   const mobileSidebarRendered = mobileSidebarOpen || mobileSidebarDragOffset !== null;
   const mobileSidebarOffsetX =
@@ -2356,7 +2399,7 @@ export function App(): React.JSX.Element {
         return enabledAgents.includes(cur) ? cur : nextDefaultAgent;
       });
     }
-    setSelectedThreadId((cur) => {
+    updateSelectedThreadId((cur) => {
       if (cur) {
         return cur;
       }
@@ -2455,11 +2498,15 @@ export function App(): React.JSX.Element {
       threadId: string,
       options?: Partial<LoadSelectedThreadOptions>,
     ) => {
+      const selectedThreadRevision = selectedThreadRevisionRef.current;
       const nextLoadRevision =
         (threadLoadRevisionByIdRef.current.get(threadId) ?? 0) + 1;
       threadLoadRevisionByIdRef.current.set(threadId, nextLoadRevision);
       const isCurrentLoadRevision = (): boolean =>
         threadLoadRevisionByIdRef.current.get(threadId) === nextLoadRevision;
+      const isCurrentSelectedThreadRevision = (): boolean =>
+        selectedThreadIdRef.current === threadId &&
+        selectedThreadRevisionRef.current === selectedThreadRevision;
       const includeTurns = options?.includeTurns ?? true;
       const includeStreamEvents = options?.includeStreamEvents ?? includeTurns;
       const chatVisibleItemLimit =
@@ -2574,11 +2621,11 @@ export function App(): React.JSX.Element {
           : live;
       const shouldLoadStreamEvents =
         canReadStreamEvents &&
-        (activeTabRef.current === "debug" ||
-          (threadAgentId === "codex" && selectedThreadIdRef.current === threadId)) &&
+        isCurrentSelectedThreadRevision() &&
+        (activeTabRef.current === "debug" || threadAgentId === "codex") &&
         (includeStreamEvents || threadAgentId === "codex");
       const shouldUpdateSelectedThread =
-        selectedThreadIdRef.current === threadId;
+        isCurrentSelectedThreadRevision();
       const existingCachedState =
         threadViewStateCacheRef.current.get(threadId) ?? null;
       let nextStreamEvents = retainStreamEventsForView(
@@ -2836,14 +2883,14 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     const onPopState = () => {
       const next = parseUiStateFromPath(window.location.pathname);
-      setSelectedThreadId(next.threadId);
+      updateSelectedThreadId(next.threadId);
       setActiveTab(next.tab);
     };
     window.addEventListener("popstate", onPopState);
     return () => {
       window.removeEventListener("popstate", onPopState);
     };
-  }, []);
+  }, [updateSelectedThreadId]);
 
   useEffect(() => {
     const nextPath = buildPathFromUiState(selectedThreadId, activeTab);
@@ -3581,8 +3628,7 @@ export function App(): React.JSX.Element {
               created.thread,
             ),
           );
-          setSelectedThreadId(threadId);
-          selectedThreadIdRef.current = threadId;
+          updateSelectedThreadId(threadId);
         }
 
         await sendMessage({
@@ -3608,6 +3654,7 @@ export function App(): React.JSX.Element {
       refreshAll,
       selectedAgentId,
       selectedThreadId,
+      updateSelectedThreadId,
       upsertSidebarThread,
     ],
   );
@@ -3899,8 +3946,7 @@ export function App(): React.JSX.Element {
             created.thread,
           ),
         );
-        setSelectedThreadId(created.threadId);
-        selectedThreadIdRef.current = created.threadId;
+        updateSelectedThreadId(created.threadId);
         closeMobileSidebar();
         await refreshAll();
       } catch (e) {
@@ -3909,7 +3955,14 @@ export function App(): React.JSX.Element {
         setIsBusy(false);
       }
     },
-    [agentsById, closeMobileSidebar, refreshAll, selectedAgentId, upsertSidebarThread],
+    [
+      agentsById,
+      closeMobileSidebar,
+      refreshAll,
+      selectedAgentId,
+      updateSelectedThreadId,
+      upsertSidebarThread,
+    ],
   );
 
   const createThreadForSingleAgent = useCallback(
@@ -4430,7 +4483,7 @@ export function App(): React.JSX.Element {
                             key={thread.id}
                             type="button"
                             onClick={() => {
-                              setSelectedThreadId(thread.id);
+                              updateSelectedThreadId(thread.id);
                               closeMobileSidebar();
                             }}
                             variant="ghost"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1063,20 +1063,29 @@ function conversationProgressSignature(
     return "";
   }
 
+  const firstTurn = state.turns[0];
   const lastTurn = state.turns[state.turns.length - 1];
-  if (!lastTurn) {
+  if (!firstTurn || !lastTurn) {
     return "no-turns";
   }
 
+  const firstTurnId = firstTurn.id ?? firstTurn.turnId ?? "";
+  const firstItems = firstTurn.items ?? [];
+  const firstItem = firstItems[0];
   const lastTurnId = lastTurn.id ?? lastTurn.turnId ?? "";
-  const items = lastTurn.items ?? [];
-  const lastItem = items[items.length - 1];
+  const lastItems = lastTurn.items ?? [];
+  const lastItem = lastItems[lastItems.length - 1];
 
   return [
     String(state.turns.length),
+    firstTurnId,
+    firstTurn.status,
+    String(firstItems.length),
+    firstItem?.id ?? "",
+    firstItem?.type ?? "",
     lastTurnId,
     lastTurn.status,
-    String(items.length),
+    String(lastItems.length),
     lastItem?.id ?? "",
     lastItem?.type ?? "",
   ].join("|");
@@ -3134,7 +3143,6 @@ export function App(): React.JSX.Element {
     let source: EventSource | null = null;
     let reconnectTimer: number | null = null;
     let reconnectDelayMs = 1000;
-    let hasOpenedConnection = false;
 
     const scheduleRefresh = (
       refreshCore: boolean,
@@ -3221,10 +3229,6 @@ export function App(): React.JSX.Element {
       source.onopen = () => {
         setIsUnifiedEventsConnected(true);
         reconnectDelayMs = 1000;
-        if (hasOpenedConnection) {
-          return;
-        }
-        hasOpenedConnection = true;
         scheduleRefresh(
           true,
           activeTabRef.current === "debug",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -84,6 +84,7 @@ import { PendingInformationalRequestCard } from "@/components/PendingInformation
 import { PendingRequestCard } from "@/components/PendingRequestCard";
 import { SidebarThreadWaitingIndicators } from "@/components/SidebarThreadWaitingIndicators";
 import { StreamEventCard } from "@/components/StreamEventCard";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -178,6 +179,7 @@ interface NormalizedTokenUsage {
 interface LoadSelectedThreadOptions {
   includeTurns: boolean;
   includeStreamEvents: boolean;
+  chatVisibleItemLimit?: number | null;
 }
 
 interface CachedThreadViewState {
@@ -260,6 +262,25 @@ function threadLabel(thread: Thread): string {
   const text = thread.preview.trim();
   if (!text) return `thread ${thread.id.slice(0, 8)}`;
   return text;
+}
+
+function shouldClearResolvedThreadError(
+  currentError: string,
+  threadId: string,
+): boolean {
+  const normalized = currentError.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+
+  if (normalized === "Thread provider is still loading") {
+    return true;
+  }
+
+  return (
+    normalized.includes(threadId) &&
+    normalized.includes("is not registered")
+  );
 }
 
 function threadRecencyTimestamp(thread: Thread): number {
@@ -488,13 +509,22 @@ function hasSameThreadListErrors(
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function hasRenderableUserMessageContent(
+  item: Extract<ConversationTurnItem, { type: "userMessage" | "steeringUserMessage" }>,
+): boolean {
+  return item.content.some((part) => {
+    if (part.type === "text") {
+      return part.text.length > 0;
+    }
+    return part.url.length > 0;
+  });
+}
+
 function shouldRenderConversationItem(item: ConversationTurnItem): boolean {
   switch (item.type) {
     case "userMessage":
     case "steeringUserMessage":
-      return item.content.some(
-        (part) => part.type === "text" && part.text.length > 0,
-      );
+      return hasRenderableUserMessageContent(item);
     case "agentMessage":
       return item.text.length > 0;
     case "reasoning": {
@@ -561,6 +591,9 @@ const AGENT_CACHE_TTL_MS = 30_000;
 const PROVIDER_CATALOG_CACHE_TTL_MS = 20_000;
 const CORE_REFRESH_INTERVAL_MS = 5_000;
 const SELECTED_THREAD_REFRESH_INTERVAL_MS = 1_000;
+const MAX_RETAINED_DEBUG_STREAM_EVENTS = 80;
+const MAX_CACHED_THREAD_VIEW_STATES = 10;
+const MAX_CACHED_HISTORY_DETAILS = 40;
 const DEBUG_UI_ENABLED = import.meta.env.MODE !== "production";
 const MOBILE_SIDEBAR_WIDTH_PX = 256;
 const MOBILE_SWIPE_EDGE_PX = 24;
@@ -605,6 +638,237 @@ function sortEffortOptions(options: string[]): string[] {
 
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function setBoundedCacheEntry<K, V>(
+  cache: Map<K, V>,
+  key: K,
+  value: V,
+  maxEntries: number,
+): void {
+  if (cache.has(key)) {
+    cache.delete(key);
+  }
+  cache.set(key, value);
+  while (cache.size > maxEntries) {
+    const oldestKey = cache.keys().next().value as K | undefined;
+    if (oldestKey === undefined) {
+      return;
+    }
+    cache.delete(oldestKey);
+  }
+}
+
+export function pruneMapToRetainedKeys<K, V>(
+  cache: Map<K, V>,
+  retainedKeys: Iterable<K>,
+): void {
+  const retainedKeySet = new Set(retainedKeys);
+  for (const key of [...cache.keys()]) {
+    if (retainedKeySet.has(key)) {
+      continue;
+    }
+    cache.delete(key);
+  }
+}
+
+function trimConversationStateForChatWindow(
+  state: NonNullable<ReadThreadResponse["thread"]>,
+  visibleItemLimit: number,
+): NonNullable<ReadThreadResponse["thread"]> {
+  const turns = state.turns;
+  if (visibleItemLimit <= 0 || turns.length === 0) {
+    return state;
+  }
+
+  // Keep one extra renderable item in memory so the chat view can still show
+  // that there are older messages available without storing the entire thread.
+  const renderableBudget = visibleItemLimit + 1;
+  let renderableCount = 0;
+  let firstTurnIndex = -1;
+  let firstItemIndex = -1;
+
+  for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
+    const turn = turns[turnIndex];
+    if (!turn) {
+      continue;
+    }
+    const items = turn.items ?? [];
+    for (let itemIndex = items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      const item = items[itemIndex];
+      if (!item || !shouldRenderConversationItem(item)) {
+        continue;
+      }
+      renderableCount += 1;
+      if (renderableCount === renderableBudget) {
+        firstTurnIndex = turnIndex;
+        firstItemIndex = itemIndex;
+      }
+    }
+  }
+
+  if (
+    renderableCount <= renderableBudget ||
+    firstTurnIndex === -1 ||
+    firstItemIndex === -1
+  ) {
+    return state;
+  }
+
+  const trimmedTurns = turns.slice(firstTurnIndex).map((turn, index) => {
+    if (index !== 0) {
+      return turn;
+    }
+    return {
+      ...turn,
+      items: (turn.items ?? []).slice(firstItemIndex),
+    };
+  });
+
+  return {
+    ...state,
+    turns: trimmedTurns,
+  };
+}
+
+function countRenderableConversationItems(
+  state: NonNullable<ReadThreadResponse["thread"]>,
+): number {
+  let renderableCount = 0;
+  for (const turn of state.turns) {
+    if (!turn) {
+      continue;
+    }
+    for (const item of turn.items ?? []) {
+      if (item && shouldRenderConversationItem(item)) {
+        renderableCount += 1;
+      }
+    }
+  }
+  return renderableCount;
+}
+
+export function normalizeReadThreadResponseForChatWindow(
+  state: ReadThreadResponse | null,
+  visibleItemLimit: number | null,
+): ReadThreadResponse | null {
+  if (!state || visibleItemLimit === null || visibleItemLimit <= 0) {
+    return state;
+  }
+
+  const renderableBudget = visibleItemLimit + 1;
+  if (countRenderableConversationItems(state.thread) <= renderableBudget) {
+    return state;
+  }
+
+  return {
+    ...state,
+    thread: trimConversationStateForChatWindow(state.thread, visibleItemLimit),
+  };
+}
+
+export function retainStreamEventsForView<T>(
+  events: readonly T[],
+  activeTab: "chat" | "debug",
+  debugLimit = MAX_RETAINED_DEBUG_STREAM_EVENTS,
+): T[] {
+  if (events.length === 0) {
+    return [];
+  }
+
+  if (activeTab === "debug") {
+    if (!Number.isInteger(debugLimit) || debugLimit <= 0) {
+      return [];
+    }
+    return events.length <= debugLimit
+      ? [...events]
+      : events.slice(-debugLimit);
+  }
+
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event === undefined) {
+      continue;
+    }
+    if (StreamTokenUsageUpdatedEventSchema.safeParse(event).success) {
+      return [event];
+    }
+  }
+
+  return [];
+}
+
+export function normalizeLiveStateResponseForChatWindow(
+  state: LiveStateResponse | null,
+  visibleItemLimit: number | null,
+): LiveStateResponse | null {
+  if (
+    !state ||
+    visibleItemLimit === null ||
+    visibleItemLimit <= 0 ||
+    state.conversationState === null
+  ) {
+    return state;
+  }
+
+  const renderableBudget = visibleItemLimit + 1;
+  if (
+    countRenderableConversationItems(state.conversationState) <= renderableBudget
+  ) {
+    return state;
+  }
+
+  return {
+    ...state,
+    conversationState: trimConversationStateForChatWindow(
+      state.conversationState,
+      visibleItemLimit,
+    ),
+  };
+}
+
+export function normalizeCachedThreadViewStateForStorage(
+  state: CachedThreadViewState,
+  options: {
+    activeTab: "chat" | "debug";
+    chatVisibleItemLimit: number;
+  },
+): CachedThreadViewState {
+  return {
+    readThreadState: normalizeReadThreadResponseForChatWindow(
+      state.readThreadState,
+      options.chatVisibleItemLimit,
+    ),
+    liveState: normalizeLiveStateResponseForChatWindow(
+      state.liveState,
+      options.chatVisibleItemLimit,
+    ),
+    streamEvents: retainStreamEventsForView(state.streamEvents, options.activeTab),
+  };
+}
+
+function normalizeAppViewSnapshotForStorage(
+  snapshot: AppViewSnapshot,
+  chatVisibleItemLimit: number,
+): AppViewSnapshot {
+  const normalizedThreadState = normalizeCachedThreadViewStateForStorage(
+    {
+      readThreadState: snapshot.readThreadState,
+      liveState: snapshot.liveState,
+      streamEvents: snapshot.streamEvents,
+    },
+    {
+      activeTab: snapshot.activeTab,
+      chatVisibleItemLimit,
+    },
+  );
+
+  return {
+    ...snapshot,
+    readThreadState: normalizedThreadState.readThreadState,
+    liveState: normalizedThreadState.liveState,
+    streamEvents: normalizedThreadState.streamEvents,
+  };
 }
 
 function AgentFavicon({
@@ -862,6 +1126,32 @@ function basenameFromPath(value: string): string {
   return parts[parts.length - 1] ?? normalized;
 }
 
+function displayPathFromValue(value: string): string {
+  return value.trim().replaceAll("\\", "/").replace(/\/+/g, "/").replace(/\/+$/, "");
+}
+
+function normalizeProjectPathKey(value: string): string {
+  const displayPath = displayPathFromValue(value);
+  if (!displayPath) {
+    return "";
+  }
+
+  if (/^[a-z]:\//i.test(displayPath) || displayPath.startsWith("//")) {
+    return displayPath.toLowerCase();
+  }
+
+  return displayPath;
+}
+
+function projectPathHint(value: string): string | null {
+  const displayPath = displayPathFromValue(value);
+  if (!displayPath) {
+    return null;
+  }
+
+  return displayPath;
+}
+
 function normalizeManualGroupOrder(
   manualOrder: readonly string[],
   autoSortedKeys: readonly string[],
@@ -1071,10 +1361,23 @@ export function App(): React.JSX.Element {
   );
   const initialSnapshot = ENABLE_VIEW_SNAPSHOT_CACHE
     ? appViewSnapshotCache
+      ? normalizeAppViewSnapshotForStorage(
+          appViewSnapshotCache,
+          INITIAL_VISIBLE_CHAT_ITEMS,
+        )
+      : null
     : null;
   const initialTab: "chat" | "debug" = DEBUG_UI_ENABLED
     ? initialSnapshot?.activeTab ?? initialUiState.tab
     : "chat";
+  const initialStreamEvents = useMemo(
+    () =>
+      retainStreamEventsForView(
+        initialSnapshot?.streamEvents ?? [],
+        initialTab,
+      ),
+    [initialSnapshot?.streamEvents, initialTab],
+  );
 
   /* State */
   const [error, setError] = useState("");
@@ -1101,7 +1404,7 @@ export function App(): React.JSX.Element {
     );
   const [streamEvents, setStreamEvents] = useState<
     StreamEventsResponse["events"]
-  >(initialSnapshot?.streamEvents ?? []);
+  >(initialStreamEvents);
   const [modes, setModes] = useState<ModesResponse["data"]>(
     initialSnapshot?.modes ?? [],
   );
@@ -1165,6 +1468,8 @@ export function App(): React.JSX.Element {
   const [projectColors, setProjectColors] = useState<Record<string, GroupColor>>(
     () => readProjectColors(),
   );
+  const [isUnifiedEventsConnected, setIsUnifiedEventsConnected] =
+    useState(false);
   const [rateLimits, setRateLimits] = useState<
     Awaited<ReturnType<typeof getAccountRateLimits>> | null
   >(null);
@@ -1173,6 +1478,7 @@ export function App(): React.JSX.Element {
 
   /* Refs */
   const selectedThreadIdRef = useRef<string | null>(null);
+  const visibleChatItemLimitRef = useRef(INITIAL_VISIBLE_CHAT_ITEMS);
   const activeTabRef = useRef<"chat" | "debug">(
     initialTab,
   );
@@ -1191,6 +1497,7 @@ export function App(): React.JSX.Element {
   const lastAppliedModeSignatureRef = useRef("");
   const hasHydratedAgentSelectionRef = useRef(false);
   const threadProviderByIdRef = useRef<Map<string, AgentId>>(new Map());
+  const threadLoadRevisionByIdRef = useRef<Map<string, number>>(new Map());
   const optimisticSelectedThreadIdsRef = useRef<Set<string>>(new Set());
   const loadCoreDataRef = useRef<(() => Promise<void>) | null>(null);
   const loadSelectedThreadRef = useRef<
@@ -1207,7 +1514,7 @@ export function App(): React.JSX.Element {
             {
               readThreadState: initialSnapshot.readThreadState,
               liveState: initialSnapshot.liveState,
-              streamEvents: initialSnapshot.streamEvents,
+              streamEvents: initialStreamEvents,
             },
           ],
         ])
@@ -1290,24 +1597,46 @@ export function App(): React.JSX.Element {
       key: string;
       label: string;
       projectPath: string | null;
+      pathHint: string | null;
+      isHistoricalOnly: boolean;
       latestUpdatedAt: number;
       preferredAgentId: AgentId | null;
       threads: Thread[];
       userColor: string | null;
     };
     const groups = new Map<string, Group>();
+    const currentProjectPathKeysByAgent = new Map<AgentId, Set<string>>();
+
+    for (const descriptor of agentDescriptors) {
+      if (!descriptor.capabilities.canListProjectDirectories) {
+        continue;
+      }
+      const projectPathKeys = new Set<string>();
+      for (const directory of descriptor.projectDirectories) {
+        const projectPath = displayPathFromValue(directory);
+        if (!projectPath) {
+          continue;
+        }
+        projectPathKeys.add(normalizeProjectPathKey(projectPath));
+      }
+      currentProjectPathKeysByAgent.set(descriptor.id, projectPathKeys);
+    }
 
     for (const thread of threads) {
       const cwd =
         typeof thread.cwd === "string" && thread.cwd.trim()
           ? thread.cwd.trim()
           : null;
-      const projectPath = cwd;
-      const key = projectPath ? `project:${projectPath}` : "project:unknown";
+      const projectPath = cwd ? displayPathFromValue(cwd) : null;
+      const projectKey = projectPath ? normalizeProjectPathKey(projectPath) : "";
+      const key = projectKey ? `project:${projectKey}` : "project:unknown";
       const label = projectPath ? basenameFromPath(projectPath) : "Unknown";
       const updatedAt = threadRecencyTimestamp(thread);
       const threadAgentId = thread.provider;
       const projectColor = projectColors[key] ?? null;
+      const currentProjectPathKeys = currentProjectPathKeysByAgent.get(
+        threadAgentId,
+      );
 
       const existing = groups.get(key);
       if (existing) {
@@ -1323,6 +1652,11 @@ export function App(): React.JSX.Element {
           key,
           label,
           projectPath,
+          pathHint: projectPath ? projectPathHint(projectPath) : null,
+          isHistoricalOnly:
+            projectKey.length > 0 &&
+            currentProjectPathKeys !== undefined &&
+            !currentProjectPathKeys.has(projectKey),
           latestUpdatedAt: updatedAt,
           preferredAgentId: threadAgentId,
           threads: [thread],
@@ -1333,18 +1667,20 @@ export function App(): React.JSX.Element {
 
     for (const descriptor of agentDescriptors) {
       for (const directory of descriptor.projectDirectories) {
-        const normalized = directory.trim();
-        if (!normalized) {
+        const projectPath = displayPathFromValue(directory);
+        if (!projectPath) {
           continue;
         }
-        const key = `project:${normalized}`;
+        const key = `project:${normalizeProjectPathKey(projectPath)}`;
         if (groups.has(key)) {
           continue;
         }
         groups.set(key, {
           key,
-          label: basenameFromPath(normalized),
-          projectPath: normalized,
+          label: basenameFromPath(projectPath),
+          projectPath,
+          pathHint: projectPathHint(projectPath),
+          isHistoricalOnly: false,
           latestUpdatedAt: 0,
           preferredAgentId: descriptor.id,
           threads: [],
@@ -1358,6 +1694,18 @@ export function App(): React.JSX.Element {
     }
 
     const allGroups = Array.from(groups.values());
+    const labelCounts = new Map<string, number>();
+    for (const group of allGroups) {
+      labelCounts.set(group.label, (labelCounts.get(group.label) ?? 0) + 1);
+    }
+    for (const group of allGroups) {
+      if (
+        (labelCounts.get(group.label) ?? 0) < 2 &&
+        !group.isHistoricalOnly
+      ) {
+        group.pathHint = null;
+      }
+    }
     const autoSortedKeys = allGroups
       .slice()
       .sort((left, right) => right.latestUpdatedAt - left.latestUpdatedAt)
@@ -2107,18 +2455,37 @@ export function App(): React.JSX.Element {
       threadId: string,
       options?: Partial<LoadSelectedThreadOptions>,
     ) => {
+      const nextLoadRevision =
+        (threadLoadRevisionByIdRef.current.get(threadId) ?? 0) + 1;
+      threadLoadRevisionByIdRef.current.set(threadId, nextLoadRevision);
+      const isCurrentLoadRevision = (): boolean =>
+        threadLoadRevisionByIdRef.current.get(threadId) === nextLoadRevision;
       const includeTurns = options?.includeTurns ?? true;
       const includeStreamEvents = options?.includeStreamEvents ?? includeTurns;
+      const chatVisibleItemLimit =
+        options?.chatVisibleItemLimit ??
+        (activeTabRef.current === "chat"
+          ? visibleChatItemLimitRef.current
+          : null);
       let threadAgentId = threadProviderByIdRef.current.get(threadId) ?? null;
       let read =
         threadAgentId === null
           ? await readThread(threadId, {
               includeTurns,
+              ...(chatVisibleItemLimit !== null
+                ? { maxRenderableItems: chatVisibleItemLimit }
+                : {}),
             })
           : await readThread(threadId, {
               includeTurns,
               provider: threadAgentId,
+              ...(chatVisibleItemLimit !== null
+                ? { maxRenderableItems: chatVisibleItemLimit }
+                : {}),
             });
+      if (!isCurrentLoadRevision()) {
+        return;
+      }
       threadAgentId = read.thread.provider;
       threadProviderByIdRef.current.set(threadId, threadAgentId);
 
@@ -2137,26 +2504,74 @@ export function App(): React.JSX.Element {
         read = await readThread(threadId, {
           includeTurns: true,
           provider: threadAgentId,
+          ...(chatVisibleItemLimit !== null
+            ? { maxRenderableItems: chatVisibleItemLimit }
+            : {}),
         });
+        if (!isCurrentLoadRevision()) {
+          return;
+        }
       }
 
-      const live = canReadLiveState
-        ? await getLiveState(threadId, threadAgentId)
-        : {
-            ok: true as const,
+      let live: LiveStateResponse = {
+        ok: true,
+        threadId,
+        ownerClientId: null,
+        conversationState: null,
+        liveStateError: null,
+      };
+      if (canReadLiveState) {
+        try {
+          if (chatVisibleItemLimit !== null) {
+            live = await getLiveState(threadId, threadAgentId, {
+              maxRenderableItems: chatVisibleItemLimit,
+            });
+          } else {
+            live = await getLiveState(threadId, threadAgentId);
+          }
+          if (!isCurrentLoadRevision()) {
+            return;
+          }
+        } catch (error) {
+          console.error("Failed to load live state", error);
+          live = {
+            ok: true,
             threadId,
             ownerClientId: null,
             conversationState: null,
-            liveStateError: null,
+            liveStateError: {
+              kind: "reductionFailed",
+              message: toErrorMessage(error),
+              eventIndex: null,
+              patchIndex: null,
+            },
           };
+        }
+      }
 
       if (!shouldReadTurns && live.conversationState === null) {
         read = await readThread(threadId, {
           includeTurns: true,
           provider: threadAgentId,
+          ...(chatVisibleItemLimit !== null
+            ? { maxRenderableItems: chatVisibleItemLimit }
+            : {}),
         });
+        if (!isCurrentLoadRevision()) {
+          return;
+        }
         shouldReadTurns = true;
       }
+      const readForView =
+        shouldReadTurns && chatVisibleItemLimit !== null
+          ? normalizeReadThreadResponseForChatWindow(read, chatVisibleItemLimit) ??
+            read
+          : read;
+      const liveForView =
+        live.conversationState !== null && chatVisibleItemLimit !== null
+          ? normalizeLiveStateResponseForChatWindow(live, chatVisibleItemLimit) ??
+            live
+          : live;
       const shouldLoadStreamEvents =
         canReadStreamEvents &&
         (activeTabRef.current === "debug" ||
@@ -2166,24 +2581,50 @@ export function App(): React.JSX.Element {
         selectedThreadIdRef.current === threadId;
       const existingCachedState =
         threadViewStateCacheRef.current.get(threadId) ?? null;
-      let nextStreamEvents = existingCachedState?.streamEvents ?? [];
+      let nextStreamEvents = retainStreamEventsForView(
+        existingCachedState?.streamEvents ?? [],
+        activeTabRef.current,
+      );
+      const cacheChatVisibleItemLimit =
+        activeTabRef.current === "chat"
+          ? visibleChatItemLimitRef.current
+          : INITIAL_VISIBLE_CHAT_ITEMS;
+      const buildCachedThreadState = (
+        streamEventsForCache: StreamEventsResponse["events"],
+      ): CachedThreadViewState =>
+        normalizeCachedThreadViewStateForStorage(
+          {
+            readThreadState: shouldReadTurns
+              ? readForView
+              : (existingCachedState?.readThreadState ?? null),
+            liveState: liveForView,
+            streamEvents: streamEventsForCache,
+          },
+          {
+            activeTab: activeTabRef.current,
+            chatVisibleItemLimit: cacheChatVisibleItemLimit,
+          },
+        );
+      if (!isCurrentLoadRevision()) {
+        return;
+      }
       startTransition(() => {
         setThreads((previousThreads) => {
-          const nextIsGenerating = live.conversationState
-            ? isThreadGeneratingState(live.conversationState)
-            : isThreadGeneratingState(read.thread);
+          const nextIsGenerating = liveForView.conversationState
+            ? isThreadGeneratingState(liveForView.conversationState)
+            : isThreadGeneratingState(readForView.thread);
           const nextThreads = previousThreads.map((threadSummary) => {
-            if (threadSummary.id !== read.thread.id) {
+            if (threadSummary.id !== readForView.thread.id) {
               return threadSummary;
             }
 
             const nextUpdatedAt =
-              typeof read.thread.updatedAt === "number"
-                ? Math.max(threadSummary.updatedAt, read.thread.updatedAt)
+              typeof readForView.thread.updatedAt === "number"
+                ? Math.max(threadSummary.updatedAt, readForView.thread.updatedAt)
                 : threadSummary.updatedAt;
             const nextTitle =
-              read.thread.title !== undefined
-                ? read.thread.title
+              readForView.thread.title !== undefined
+                ? readForView.thread.title
                 : threadSummary.title;
             const hadGenerating = threadSummary.isGenerating ?? false;
 
@@ -2217,62 +2658,102 @@ export function App(): React.JSX.Element {
         setLiveState((prev) => {
           if (
             buildLiveStateSyncSignature(prev) ===
-            buildLiveStateSyncSignature(live)
+            buildLiveStateSyncSignature(liveForView)
           ) {
             return prev;
           }
-          return live;
+          return liveForView;
         });
         if (shouldReadTurns) {
           setReadThreadState((prev) => {
             if (
               buildReadThreadSyncSignature(prev) ===
-              buildReadThreadSyncSignature(read)
+              buildReadThreadSyncSignature(readForView)
             ) {
               return prev;
             }
-            return read;
+            return readForView;
           });
         }
       });
 
-      threadViewStateCacheRef.current.set(threadId, {
-        readThreadState: shouldReadTurns
-          ? read
-          : (existingCachedState?.readThreadState ?? null),
-        liveState: live,
-        streamEvents: nextStreamEvents,
-      });
+      setBoundedCacheEntry(
+        threadViewStateCacheRef.current,
+        threadId,
+        buildCachedThreadState(nextStreamEvents),
+        MAX_CACHED_THREAD_VIEW_STATES,
+      );
+      pruneMapToRetainedKeys(threadLoadRevisionByIdRef.current, [
+        ...threadViewStateCacheRef.current.keys(),
+        ...(selectedThreadIdRef.current ? [selectedThreadIdRef.current] : []),
+      ]);
+      if (shouldUpdateSelectedThread) {
+        startTransition(() => {
+          setStreamEvents((prev) => {
+            const prevLast = prev[prev.length - 1];
+            const nextLast = nextStreamEvents[nextStreamEvents.length - 1];
+            const prevLastSignature = prevLast ? JSON.stringify(prevLast) : "";
+            const nextLastSignature = nextLast ? JSON.stringify(nextLast) : "";
+            if (
+              prev.length === nextStreamEvents.length &&
+              prevLastSignature === nextLastSignature
+            ) {
+              return prev;
+            }
+            return nextStreamEvents;
+          });
+        });
+      }
+      if (shouldUpdateSelectedThread) {
+        setError((current) =>
+          shouldClearResolvedThreadError(current, threadId) ? "" : current,
+        );
+      }
 
       if (!shouldLoadStreamEvents) {
         return;
       }
 
-      const stream = await getStreamEvents(threadId, threadAgentId);
-      nextStreamEvents = stream.events;
-      threadViewStateCacheRef.current.set(threadId, {
-        readThreadState: shouldReadTurns
-          ? read
-          : (existingCachedState?.readThreadState ?? null),
-        liveState: live,
-        streamEvents: nextStreamEvents,
-      });
+      let stream: StreamEventsResponse;
+      try {
+        stream = await getStreamEvents(threadId, threadAgentId);
+      } catch (error) {
+        console.error("Failed to load stream events", error);
+        return;
+      }
+      if (!isCurrentLoadRevision()) {
+        return;
+      }
+      nextStreamEvents = retainStreamEventsForView(
+        stream.events,
+        activeTabRef.current,
+      );
+      setBoundedCacheEntry(
+        threadViewStateCacheRef.current,
+        threadId,
+        buildCachedThreadState(nextStreamEvents),
+        MAX_CACHED_THREAD_VIEW_STATES,
+      );
+      pruneMapToRetainedKeys(threadLoadRevisionByIdRef.current, [
+        ...threadViewStateCacheRef.current.keys(),
+        ...(selectedThreadIdRef.current ? [selectedThreadIdRef.current] : []),
+      ]);
       if (selectedThreadIdRef.current !== threadId) {
         return;
       }
       startTransition(() => {
         setStreamEvents((prev) => {
           const prevLast = prev[prev.length - 1];
-          const nextLast = stream.events[stream.events.length - 1];
+          const nextLast = nextStreamEvents[nextStreamEvents.length - 1];
           const prevLastSignature = prevLast ? JSON.stringify(prevLast) : "";
           const nextLastSignature = nextLast ? JSON.stringify(nextLast) : "";
           if (
-            prev.length === stream.events.length &&
+            prev.length === nextStreamEvents.length &&
             prevLastSignature === nextLastSignature
           ) {
             return prev;
           }
-          return stream.events;
+          return nextStreamEvents;
         });
       });
     },
@@ -2347,6 +2828,10 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     activeTabRef.current = activeTab;
   }, [activeTab]);
+
+  useEffect(() => {
+    visibleChatItemLimitRef.current = visibleChatItemLimit;
+  }, [visibleChatItemLimit]);
 
   useEffect(() => {
     const onPopState = () => {
@@ -2465,6 +2950,15 @@ export function App(): React.JSX.Element {
       window.clearInterval(selectedThreadRefreshIntervalRef.current);
       selectedThreadRefreshIntervalRef.current = null;
     };
+    const shouldPollSelectedThread = () => {
+      if (activeTabRef.current === "debug") {
+        return false;
+      }
+      if (activeTabRef.current === "chat" && isUnifiedEventsConnected) {
+        return false;
+      }
+      return true;
+    };
 
     if (!selectedThreadId) {
       stopSelectedThreadRefresh();
@@ -2475,18 +2969,28 @@ export function App(): React.JSX.Element {
       if (document.visibilityState === "hidden") {
         return;
       }
+      // Poll full thread snapshots only as a fallback. A healthy SSE stream is
+      // enough to keep the chat view current, while repeated full reloads can
+      // grow expensive on long-running local threads.
+      if (!shouldPollSelectedThread()) {
+        return;
+      }
       const load = loadSelectedThreadRef.current;
       if (!load) {
         return;
       }
       void load(selectedThreadId, {
         includeTurns: true,
-        includeStreamEvents: activeTabRef.current === "debug",
+        includeStreamEvents: false,
       }).catch((e) =>
         setError(toErrorMessage(e)),
       );
     };
     const resumeSelectedThreadRefresh = () => {
+      if (!shouldPollSelectedThread()) {
+        stopSelectedThreadRefresh();
+        return;
+      }
       startSelectedThreadRefresh();
       refreshSelectedThreadData();
     };
@@ -2525,21 +3029,28 @@ export function App(): React.JSX.Element {
       window.removeEventListener("pagehide", onPageHide);
       window.removeEventListener("pageshow", onPageShow);
     };
-  }, [selectedThreadId]);
+  }, [selectedThreadId, activeTab, isUnifiedEventsConnected]);
 
   useEffect(() => {
     if (!selectedThreadId) {
+      pruneMapToRetainedKeys(threadLoadRevisionByIdRef.current, []);
       setLiveState(null);
       setReadThreadState(null);
       setStreamEvents([]);
       return;
     }
+    pruneMapToRetainedKeys(threadLoadRevisionByIdRef.current, [
+      ...threadViewStateCacheRef.current.keys(),
+      selectedThreadId,
+    ]);
     const cachedState =
       threadViewStateCacheRef.current.get(selectedThreadId) ?? null;
     if (cachedState) {
       setLiveState(cachedState.liveState);
       setReadThreadState(cachedState.readThreadState);
-      setStreamEvents(cachedState.streamEvents);
+      setStreamEvents(
+        retainStreamEventsForView(cachedState.streamEvents, activeTabRef.current),
+      );
     } else {
       setLiveState(null);
       setReadThreadState(null);
@@ -2554,6 +3065,22 @@ export function App(): React.JSX.Element {
       includeStreamEvents: activeTabRef.current === "debug",
     }).catch((e) => setError(toErrorMessage(e)));
   }, [selectedThreadId]);
+
+  useEffect(() => {
+    if (!selectedThreadId) {
+      return;
+    }
+    const load = loadSelectedThreadRef.current;
+    if (!load) {
+      return;
+    }
+    void load(selectedThreadId, {
+      includeTurns: true,
+      includeStreamEvents: activeTab === "debug",
+      chatVisibleItemLimit:
+        activeTab === "chat" ? visibleChatItemLimitRef.current : null,
+    }).catch((e) => setError(toErrorMessage(e)));
+  }, [activeTab, selectedThreadId]);
 
   useEffect(() => {
     let disposed = false;
@@ -2645,6 +3172,7 @@ export function App(): React.JSX.Element {
 
       source = new EventSource(unifiedEventsUrl);
       source.onopen = () => {
+        setIsUnifiedEventsConnected(true);
         reconnectDelayMs = 1000;
         if (hasOpenedConnection) {
           return;
@@ -2711,6 +3239,7 @@ export function App(): React.JSX.Element {
       };
 
       source.onerror = () => {
+        setIsUnifiedEventsConnected(false);
         if (source) {
           source.close();
           source = null;
@@ -2733,6 +3262,7 @@ export function App(): React.JSX.Element {
         refreshHistory: false,
         refreshSelectedThread: false,
       };
+      setIsUnifiedEventsConnected(false);
       if (source) {
         source.close();
         source = null;
@@ -2870,19 +3400,22 @@ export function App(): React.JSX.Element {
     if (!ENABLE_VIEW_SNAPSHOT_CACHE) {
       return;
     }
-    appViewSnapshotCache = {
-      threads,
-      threadListErrors,
-      selectedThreadId,
-      liveState,
-      readThreadState,
-      streamEvents,
-      modes,
-      models,
-      agentDescriptors,
-      selectedAgentId,
-      activeTab,
-    };
+    appViewSnapshotCache = normalizeAppViewSnapshotForStorage(
+      {
+        threads,
+        threadListErrors,
+        selectedThreadId,
+        liveState,
+        readThreadState,
+        streamEvents,
+        modes,
+        models,
+        agentDescriptors,
+        selectedAgentId,
+        activeTab,
+      },
+      activeTab === "chat" ? visibleChatItemLimit : INITIAL_VISIBLE_CHAT_ITEMS,
+    );
   }, [
     activeTab,
     agentDescriptors,
@@ -2895,6 +3428,7 @@ export function App(): React.JSX.Element {
     streamEvents,
     threadListErrors,
     threads,
+    visibleChatItemLimit,
   ]);
 
   useEffect(() => {
@@ -2995,6 +3529,24 @@ export function App(): React.JSX.Element {
     setIsChatAtBottom(true);
     setVisibleChatItemLimit(INITIAL_VISIBLE_CHAT_ITEMS);
   }, [activeTab, scrollChatToBottom, selectedThreadId]);
+
+  const handleShowOlderChatMessages = useCallback(() => {
+    if (!selectedThreadId) {
+      return;
+    }
+    const nextLimit = visibleChatItemLimitRef.current + VISIBLE_CHAT_ITEMS_STEP;
+    visibleChatItemLimitRef.current = nextLimit;
+    setVisibleChatItemLimit(nextLimit);
+    const load = loadSelectedThreadRef.current;
+    if (!load) {
+      return;
+    }
+    void load(selectedThreadId, {
+      includeTurns: true,
+      includeStreamEvents: false,
+      chatVisibleItemLimit: nextLimit,
+    }).catch((e) => setError(toErrorMessage(e)));
+  }, [selectedThreadId]);
 
   /* Actions */
   const submitMessage = useCallback(
@@ -3286,7 +3838,12 @@ export function App(): React.JSX.Element {
     const requestId = historyDetailRequestIdRef.current + 1;
     historyDetailRequestIdRef.current = requestId;
     const detail = await getHistoryEntry(id);
-    historyDetailCacheRef.current.set(id, detail);
+    setBoundedCacheEntry(
+      historyDetailCacheRef.current,
+      id,
+      detail,
+      MAX_CACHED_HISTORY_DETAILS,
+    );
     if (historyDetailRequestIdRef.current !== requestId) {
       return;
     }
@@ -3683,13 +4240,28 @@ export function App(): React.JSX.Element {
                       }
                       variant="ghost"
                       className="h-6 flex-1 justify-start gap-1.5 rounded-lg px-1.5 py-1 text-left text-[13px] tracking-tight font-normal text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                      title={group.projectPath ?? group.label}
                     >
                       {isCollapsed ? (
                         <Folder size={13} className="shrink-0" />
                       ) : (
                         <FolderOpen size={13} className="shrink-0" />
                       )}
-                      <span className="min-w-0 truncate">{group.label}</span>
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-1.5">
+                          <span className="min-w-0 truncate">{group.label}</span>
+                          {group.isHistoricalOnly && (
+                            <Badge className="h-4 shrink-0 px-1.5 py-0 text-[9px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                              History
+                            </Badge>
+                          )}
+                        </span>
+                        {group.pathHint && (
+                          <span className="block truncate text-[10px] leading-4 text-muted-foreground/70">
+                            {group.pathHint}
+                          </span>
+                        )}
+                      </span>
                     </Button>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
@@ -4378,11 +4950,7 @@ export function App(): React.JSX.Element {
                   visibleConversationItems={visibleConversationItems}
                   isChatAtBottom={isChatAtBottom}
                   onSelectThread={handleSelectReferencedThread}
-                  onShowOlder={() => {
-                    setVisibleChatItemLimit(
-                      (limit) => limit + VISIBLE_CHAT_ITEMS_STEP,
-                    );
-                  }}
+                  onShowOlder={handleShowOlderChatMessages}
                   onScrollToBottom={() => {
                     scrollChatToBottom();
                     isChatAtBottomRef.current = true;
@@ -4688,18 +5256,32 @@ export function App(): React.JSX.Element {
                           {traceStatus?.active ? "recording" : "idle"}
                         </span>
                       </div>
-                      <Input
-                        value={traceLabel}
-                        onChange={(e) => setTraceLabel(e.target.value)}
-                        placeholder="label"
-                        className="h-7 text-base md:text-xs"
-                      />
-                      <Input
-                        value={traceNote}
-                        onChange={(e) => setTraceNote(e.target.value)}
-                        placeholder="marker note"
-                        className="h-7 text-base md:text-xs"
-                      />
+                      <div className="space-y-1">
+                        <Label htmlFor="trace-label" className="sr-only">
+                          Trace label
+                        </Label>
+                        <Input
+                          id="trace-label"
+                          name="traceLabel"
+                          value={traceLabel}
+                          onChange={(e) => setTraceLabel(e.target.value)}
+                          placeholder="label"
+                          className="h-7 text-base md:text-xs"
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <Label htmlFor="trace-note" className="sr-only">
+                          Trace marker note
+                        </Label>
+                        <Input
+                          id="trace-note"
+                          name="traceNote"
+                          value={traceNote}
+                          onChange={(e) => setTraceNote(e.target.value)}
+                          placeholder="marker note"
+                          className="h-7 text-base md:text-xs"
+                        />
+                      </div>
                       <div className="flex gap-1.5">
                         {(["Start", "Mark", "Stop"] as const).map((btn) => (
                           <Button

--- a/apps/web/src/components/ConversationItem.tsx
+++ b/apps/web/src/components/ConversationItem.tsx
@@ -1,6 +1,10 @@
 import { memo } from "react";
 import { GitBranch } from "lucide-react";
-import type { UnifiedItem, UnifiedItemKind } from "@farfield/unified-surface";
+import type {
+  JsonValue,
+  UnifiedItem,
+  UnifiedItemKind,
+} from "@farfield/unified-surface";
 import { ReasoningBlock } from "./ReasoningBlock";
 import { CommandBlock } from "./CommandBlock";
 import { DiffBlock } from "./DiffBlock";
@@ -60,7 +64,7 @@ function readImageContent(content: UserMessageLikeItem["content"]): string[] {
     .filter((url) => url.length > 0);
 }
 
-function stringifyPreview(value: unknown, maxLength = 600): string {
+function stringifyPreview(value: JsonValue, maxLength = 600): string {
   if (typeof value === "string") {
     if (value.length <= maxLength) {
       return value;
@@ -86,7 +90,9 @@ function summarizeDynamicToolContent(
   }
 
   const firstTextItem = contentItems.find(
-    (contentItem) => contentItem.type === "inputText" && contentItem.text.length > 0,
+    (contentItem) =>
+      contentItem.type === "inputText" &&
+      contentItem.text.trim().length > 0,
   );
   if (firstTextItem?.type === "inputText") {
     const text = firstTextItem.text.trim();

--- a/apps/web/src/components/ConversationItem.tsx
+++ b/apps/web/src/components/ConversationItem.tsx
@@ -25,6 +25,7 @@ const TOOL_BLOCK_TYPES: readonly UnifiedItem["type"][] = [
   "fileChange",
   "webSearch",
   "mcpToolCall",
+  "dynamicToolCall",
   "collabAgentToolCall",
   "remoteTaskCreated",
   "forkedFromConversation",
@@ -53,10 +54,92 @@ function readTextContent(content: UserMessageLikeItem["content"]): string {
     .join("\n");
 }
 
+function readImageContent(content: UserMessageLikeItem["content"]): string[] {
+  return content
+    .map((part) => (part.type === "image" ? part.url.trim() : ""))
+    .filter((url) => url.length > 0);
+}
+
+function stringifyPreview(value: unknown, maxLength = 600): string {
+  if (typeof value === "string") {
+    if (value.length <= maxLength) {
+      return value;
+    }
+    return `${value.slice(0, maxLength)}...`;
+  }
+  const serialized = JSON.stringify(value);
+  if (!serialized) {
+    return "";
+  }
+  if (serialized.length <= maxLength) {
+    return serialized;
+  }
+  return `${serialized.slice(0, maxLength)}...`;
+}
+
+function summarizeDynamicToolContent(
+  item: Extract<UnifiedItem, { type: "dynamicToolCall" }>,
+): string | null {
+  const contentItems = item.contentItems ?? [];
+  if (contentItems.length === 0) {
+    return null;
+  }
+
+  const firstTextItem = contentItems.find(
+    (contentItem) => contentItem.type === "inputText" && contentItem.text.length > 0,
+  );
+  if (firstTextItem?.type === "inputText") {
+    const text = firstTextItem.text.trim();
+    if (text.length <= 240) {
+      return text;
+    }
+    return `${text.slice(0, 240)}...`;
+  }
+
+  const imageCount = contentItems.filter(
+    (contentItem) => contentItem.type === "inputImage",
+  ).length;
+  return imageCount > 0 ? `${imageCount} image result(s)` : null;
+}
+
 interface RendererContext {
   isActive: boolean;
   toolSpacing: string;
   onSelectThread: (threadId: string) => void;
+}
+
+function renderUserMessageBubble(item: UserMessageLikeItem): React.JSX.Element | null {
+  const text = readTextContent(item.content);
+  const imageUrls = readImageContent(item.content);
+
+  if (!text && imageUrls.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[80%] rounded-2xl bg-muted px-4 py-2.5 text-sm text-foreground leading-relaxed">
+        {text && <p className="whitespace-pre-wrap break-words">{text}</p>}
+        {imageUrls.length > 0 && (
+          <div className={`${text ? "mt-3" : ""} flex flex-col gap-2`}>
+            {imageUrls.map((url, index) => (
+              <div
+                key={`${item.id}-image-${String(index)}`}
+                className="rounded-xl border border-border/60 bg-background/30 px-3 py-2"
+              >
+                <div className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+                  User image {String(index + 1)}
+                </div>
+                <div className="mt-1 break-all text-xs text-muted-foreground">
+                  {url}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 type ItemRendererMap = {
@@ -66,35 +149,9 @@ type ItemRendererMap = {
 };
 
 const ITEM_RENDERERS = {
-  userMessage: ({ item }) => {
-    const text = readTextContent(item.content);
-    if (!text) {
-      return null;
-    }
+  userMessage: ({ item }) => renderUserMessageBubble(item),
 
-    return (
-      <div className="flex justify-end">
-        <div className="max-w-[80%] rounded-2xl bg-muted px-4 py-2.5 text-sm text-foreground leading-relaxed">
-          <p className="whitespace-pre-wrap break-words">{text}</p>
-        </div>
-      </div>
-    );
-  },
-
-  steeringUserMessage: ({ item }) => {
-    const text = readTextContent(item.content);
-    if (!text) {
-      return null;
-    }
-
-    return (
-      <div className="flex justify-end">
-        <div className="max-w-[80%] rounded-2xl bg-muted px-4 py-2.5 text-sm text-foreground leading-relaxed">
-          <p className="whitespace-pre-wrap break-words">{text}</p>
-        </div>
-      </div>
-    );
-  },
+  steeringUserMessage: ({ item }) => renderUserMessageBubble(item),
 
   agentMessage: ({ item }) => {
     if (!item.text) {
@@ -239,7 +296,7 @@ const ITEM_RENDERERS = {
   ),
 
   mcpToolCall: ({ item, toolSpacing }) => {
-    const argumentsText = JSON.stringify(item.arguments);
+    const argumentsText = stringifyPreview(item.arguments);
     return (
       <div
         className={`${toolSpacing} rounded-lg border border-border bg-muted/20 px-3 py-2`}
@@ -263,6 +320,46 @@ const ITEM_RENDERERS = {
         {item.result?.content && item.result.content.length > 0 && (
           <div className="mt-2 text-xs text-muted-foreground">
             Result parts: {item.result.content.length}
+          </div>
+        )}
+        <div className="mt-2 text-[11px] text-muted-foreground font-mono whitespace-pre-wrap break-all">
+          {argumentsText}
+        </div>
+      </div>
+    );
+  },
+
+  dynamicToolCall: ({ item, toolSpacing }) => {
+    const argumentsText = stringifyPreview(item.arguments);
+    const previewText = summarizeDynamicToolContent(item);
+    return (
+      <div
+        className={`${toolSpacing} rounded-lg border border-border bg-muted/20 px-3 py-2`}
+      >
+        <div className="text-[10px] text-muted-foreground font-mono mb-1 uppercase tracking-wider">
+          Dynamic tool
+        </div>
+        <div className="text-xs text-foreground/90 whitespace-pre-wrap break-words">
+          {item.tool} ({item.status})
+        </div>
+        {item.durationMs != null && (
+          <div className="mt-1 text-[11px] text-muted-foreground font-mono">
+            {item.durationMs}ms
+          </div>
+        )}
+        {item.success != null && (
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            Success: {item.success ? "true" : "false"}
+          </div>
+        )}
+        {item.contentItems && item.contentItems.length > 0 && (
+          <div className="mt-2 text-xs text-muted-foreground">
+            Result parts: {item.contentItems.length}
+          </div>
+        )}
+        {previewText && (
+          <div className="mt-2 text-xs text-foreground/80 whitespace-pre-wrap break-words">
+            {previewText}
           </div>
         )}
         <div className="mt-2 text-[11px] text-muted-foreground font-mono whitespace-pre-wrap break-all">
@@ -394,6 +491,8 @@ function renderItem(
       return ITEM_RENDERERS.webSearch({ item, ...context });
     case "mcpToolCall":
       return ITEM_RENDERERS.mcpToolCall({ item, ...context });
+    case "dynamicToolCall":
+      return ITEM_RENDERERS.dynamicToolCall({ item, ...context });
     case "collabAgentToolCall":
       return ITEM_RENDERERS.collabAgentToolCall({ item, ...context });
     case "imageView":

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -656,7 +656,11 @@ export async function listSidebarThreads(options: {
 
 export async function readThread(
   threadId: string,
-  options?: { includeTurns?: boolean; provider?: AgentId },
+  options?: {
+    includeTurns?: boolean;
+    provider?: AgentId;
+    maxRenderableItems?: number;
+  },
 ): Promise<z.infer<typeof ReadThreadResponseSchema>> {
   const params = new URLSearchParams();
   if (typeof options?.provider === "string") {
@@ -664,6 +668,13 @@ export async function readThread(
   }
   if (typeof options?.includeTurns === "boolean") {
     params.set("includeTurns", options.includeTurns ? "1" : "0");
+  }
+  if (
+    typeof options?.maxRenderableItems === "number" &&
+    Number.isInteger(options.maxRenderableItems) &&
+    options.maxRenderableItems > 0
+  ) {
+    params.set("maxRenderableItems", String(options.maxRenderableItems));
   }
 
   const query = params.toString();
@@ -750,11 +761,17 @@ export async function listModels(
 export async function getLiveState(
   threadId: string,
   provider: AgentId,
+  options?: { maxRenderableItems?: number },
 ): Promise<z.infer<typeof LiveStateResponseSchema>> {
   const result = await runUnifiedCommand({
     kind: "readLiveState",
     provider,
     threadId,
+    ...(typeof options?.maxRenderableItems === "number" &&
+    Number.isInteger(options.maxRenderableItems) &&
+    options.maxRenderableItems > 0
+      ? { maxRenderableItems: options.maxRenderableItems }
+      : {}),
   });
 
   if (result.kind !== "readLiveState") {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -654,6 +654,19 @@ export async function listSidebarThreads(options: {
   });
 }
 
+function normalizePositiveIntegerOption(
+  value: number | undefined,
+  name: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
 export async function readThread(
   threadId: string,
   options?: {
@@ -662,6 +675,10 @@ export async function readThread(
     maxRenderableItems?: number;
   },
 ): Promise<z.infer<typeof ReadThreadResponseSchema>> {
+  const maxRenderableItems = normalizePositiveIntegerOption(
+    options?.maxRenderableItems,
+    "maxRenderableItems",
+  );
   const params = new URLSearchParams();
   if (typeof options?.provider === "string") {
     params.set("provider", options.provider);
@@ -669,12 +686,8 @@ export async function readThread(
   if (typeof options?.includeTurns === "boolean") {
     params.set("includeTurns", options.includeTurns ? "1" : "0");
   }
-  if (
-    typeof options?.maxRenderableItems === "number" &&
-    Number.isInteger(options.maxRenderableItems) &&
-    options.maxRenderableItems > 0
-  ) {
-    params.set("maxRenderableItems", String(options.maxRenderableItems));
+  if (maxRenderableItems !== undefined) {
+    params.set("maxRenderableItems", String(maxRenderableItems));
   }
 
   const query = params.toString();
@@ -763,15 +776,15 @@ export async function getLiveState(
   provider: AgentId,
   options?: { maxRenderableItems?: number },
 ): Promise<z.infer<typeof LiveStateResponseSchema>> {
+  const maxRenderableItems = normalizePositiveIntegerOption(
+    options?.maxRenderableItems,
+    "maxRenderableItems",
+  );
   const result = await runUnifiedCommand({
     kind: "readLiveState",
     provider,
     threadId,
-    ...(typeof options?.maxRenderableItems === "number" &&
-    Number.isInteger(options.maxRenderableItems) &&
-    options.maxRenderableItems > 0
-      ? { maxRenderableItems: options.maxRenderableItems }
-      : {}),
+    ...(maxRenderableItems !== undefined ? { maxRenderableItems } : {}),
   });
 
   if (result.kind !== "readLiveState") {

--- a/apps/web/src/lib/server-target.ts
+++ b/apps/web/src/lib/server-target.ts
@@ -74,22 +74,20 @@ const ApiPathSchema = z
 
 export type StoredServerTarget = z.infer<typeof StoredServerTargetSchema>;
 
-function isLocalHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-}
-
 export function getDefaultServerBaseUrl(): string {
   if (typeof window === "undefined") {
     return `http://127.0.0.1:${String(DEFAULT_SERVER_PORT)}`;
   }
 
-  const hostname = window.location.hostname;
-
-  if (isLocalHost(hostname)) {
-    return `http://127.0.0.1:${String(DEFAULT_SERVER_PORT)}`;
+  if (
+    (window.location.protocol === "http:" ||
+      window.location.protocol === "https:") &&
+    window.location.host
+  ) {
+    return window.location.origin;
   }
 
-  return window.location.origin;
+  return `http://127.0.0.1:${String(DEFAULT_SERVER_PORT)}`;
 }
 
 export function readStoredServerTarget(): StoredServerTarget | null {

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -150,6 +150,8 @@ const FEATURE_IDS: UnifiedFeatureId[] = [
 
 type ProviderId = "codex" | "opencode";
 
+// Zod preprocess helpers intentionally accept `unknown` because they normalize
+// raw query-string input before schema validation runs.
 function normalizeOptionalPositiveIntInput(value: unknown): unknown {
   if (value === null || value === undefined || value === "") {
     return undefined;

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   JsonValue,
@@ -7,10 +7,30 @@ import type {
   UnifiedItem,
   UnifiedThread,
 } from "@farfield/unified-surface";
-import { App } from "../src/App";
+import {
+  App,
+  normalizeCachedThreadViewStateForStorage,
+  normalizeReadThreadResponseForChatWindow,
+  pruneMapToRetainedKeys,
+  retainStreamEventsForView,
+} from "../src/App";
+
+type MaybePromise<T> = T | Promise<T>;
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
 
 class MockEventSource {
   private static instances: MockEventSource[] = [];
+  public onopen: ((event: Event) => void) | null = null;
   public onmessage: ((event: MessageEvent<string>) => void) | null = null;
   public onerror: ((event: Event) => void) | null = null;
 
@@ -33,8 +53,22 @@ class MockEventSource {
     const event = new MessageEvent<string>("message", {
       data: JSON.stringify(payload),
     });
-    for (const instance of MockEventSource.instances) {
+    for (const instance of [...MockEventSource.instances]) {
       instance.onmessage?.(event);
+    }
+  }
+
+  public static emitOpen(): void {
+    const event = new Event("open");
+    for (const instance of [...MockEventSource.instances]) {
+      instance.onopen?.(event);
+    }
+  }
+
+  public static emitError(): void {
+    const event = new Event("error");
+    for (const instance of [...MockEventSource.instances]) {
+      instance.onerror?.(event);
     }
   }
 
@@ -302,15 +336,19 @@ let modelsFixture: Record<
 let readThreadResolver: (
   threadId: string,
   provider: ProviderId | null,
-) => {
+  options?: {
+    includeTurns: boolean;
+    maxRenderableItems: number | null;
+  },
+) => MaybePromise<{
   ok: true;
   thread: UnifiedThreadFixture;
-} | null;
+} | null>;
 
 let liveStateResolver: (
   threadId: string,
   provider: ProviderId,
-) => {
+) => MaybePromise<{
   kind: "readLiveState";
   threadId: string;
   ownerClientId: string | null;
@@ -321,7 +359,7 @@ let liveStateResolver: (
     eventIndex: number | null;
     patchIndex: number | null;
   } | null;
-};
+}>;
 
 function buildConversationStateFixture(
   threadId: string,
@@ -503,6 +541,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 vi.stubGlobal(
@@ -552,7 +591,20 @@ vi.stubGlobal(
         providerParam === "opencode" || providerParam === "codex"
           ? providerParam
           : null;
-      const readThread = readThreadResolver(threadId, provider);
+      const maxRenderableItemsParam =
+        parsedUrl.searchParams.get("maxRenderableItems");
+      const maxRenderableItems =
+        maxRenderableItemsParam !== null
+          ? Number(maxRenderableItemsParam)
+          : null;
+      const readThread = await readThreadResolver(threadId, provider, {
+        includeTurns: parsedUrl.searchParams.get("includeTurns") !== "false",
+        maxRenderableItems:
+          typeof maxRenderableItems === "number" &&
+          Number.isFinite(maxRenderableItems)
+            ? maxRenderableItems
+            : null,
+      });
       if (readThread) {
         return jsonResponse(readThread);
       }
@@ -607,7 +659,7 @@ vi.stubGlobal(
       if (body.kind === "readLiveState") {
         return jsonResponse({
           ok: true,
-          result: liveStateResolver(body.threadId ?? "", body.provider),
+          result: await liveStateResolver(body.threadId ?? "", body.provider),
         });
       }
 
@@ -651,6 +703,201 @@ vi.stubGlobal(
 );
 
 describe("App", () => {
+  it("retains only the latest token-usage event outside debug view", () => {
+    const firstTokenUsageEvent = {
+      type: "broadcast",
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        tokenUsage: {
+          total_token_usage: {
+            total_tokens: 100,
+          },
+          last_token_usage: {
+            total_tokens: 25,
+          },
+          model_context_window: 200_000,
+        },
+      },
+    } satisfies JsonValue;
+    const secondTokenUsageEvent = {
+      type: "broadcast",
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        tokenUsage: {
+          total_token_usage: {
+            total_tokens: 140,
+          },
+          last_token_usage: {
+            total_tokens: 40,
+          },
+          model_context_window: 200_000,
+        },
+      },
+    } satisfies JsonValue;
+    const events = [
+      { type: "broadcast", method: "threadUpdated", params: {} },
+      firstTokenUsageEvent,
+      { type: "broadcast", method: "noop", params: { value: "ignored" } },
+      secondTokenUsageEvent,
+    ] satisfies JsonValue[];
+
+    expect(retainStreamEventsForView(events, "chat")).toEqual([
+      secondTokenUsageEvent,
+    ]);
+    expect(retainStreamEventsForView(events, "debug", 2)).toEqual(
+      events.slice(-2),
+    );
+    expect(
+      retainStreamEventsForView(
+        [{ type: "broadcast", method: "threadUpdated", params: {} }],
+        "chat",
+      ),
+    ).toEqual([]);
+  });
+
+  it("reuses already-windowed readThread responses without cloning", () => {
+    const response = {
+      thread: buildConversationStateFixture("thread-windowed", "gpt-5.3-codex", {
+        turnItems: Array.from({ length: 91 }, (_, index) => ({
+          id: `windowed-item-${index}`,
+          type: "agentMessage",
+          text: `windowed-${index}`,
+        })),
+      }),
+    } satisfies { thread: UnifiedThreadFixture };
+
+    const normalized = normalizeReadThreadResponseForChatWindow(response, 90);
+
+    expect(normalized).toBe(response);
+  });
+
+  it("prunes stale thread load revisions to retained thread ids", () => {
+    const revisions = new Map<string, number>([
+      ["thread-1", 1],
+      ["thread-2", 2],
+      ["thread-3", 3],
+    ]);
+
+    pruneMapToRetainedKeys(revisions, ["thread-2", "thread-3"]);
+
+    expect([...revisions.entries()]).toEqual([
+      ["thread-2", 2],
+      ["thread-3", 3],
+    ]);
+  });
+
+  it("counts image-only user messages when trimming chat windows", () => {
+    const response = {
+      thread: buildConversationStateFixture(
+        "thread-windowed-images",
+        "gpt-5.3-codex",
+        {
+          turnItems: Array.from({ length: 95 }, (_, index) => ({
+            id: `windowed-image-${index}`,
+            type: "userMessage",
+            content: [
+              {
+                type: "image",
+                url: `https://example.com/image-${index}.png`,
+              },
+            ],
+          })),
+        },
+      ),
+    } satisfies { thread: UnifiedThreadFixture };
+
+    const normalized = normalizeReadThreadResponseForChatWindow(response, 90);
+
+    expect(normalized?.thread.turns[0]?.items).toHaveLength(91);
+    const firstItem = normalized?.thread.turns[0]?.items[0];
+    expect(firstItem?.type).toBe("userMessage");
+  });
+
+  it("normalizes cached thread state before storing it", () => {
+    const oversizedTurnItems: UnifiedItem[] = Array.from(
+      { length: 95 },
+      (_, index) => ({
+        id: `cached-item-${index}`,
+        type: "agentMessage",
+        text: `cached-message-${index}`,
+      }),
+    );
+    const tokenUsageEvents = [
+      {
+        type: "broadcast",
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-cache-normalized",
+          tokenUsage: {
+            total_token_usage: {
+              total_tokens: 10,
+            },
+            last_token_usage: {
+              total_tokens: 5,
+            },
+            model_context_window: 100,
+          },
+        },
+      },
+      {
+        type: "broadcast",
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-cache-normalized",
+          tokenUsage: {
+            total_token_usage: {
+              total_tokens: 20,
+            },
+            last_token_usage: {
+              total_tokens: 10,
+            },
+            model_context_window: 100,
+          },
+        },
+      },
+    ] satisfies JsonValue[];
+
+    const normalized = normalizeCachedThreadViewStateForStorage(
+      {
+        readThreadState: {
+          thread: buildConversationStateFixture(
+            "thread-cache-normalized",
+            "gpt-5.3-codex",
+            {
+              turnItems: oversizedTurnItems,
+            },
+          ),
+        },
+        liveState: {
+          ok: true,
+          threadId: "thread-cache-normalized",
+          ownerClientId: "owner-1",
+          conversationState: buildConversationStateFixture(
+            "thread-cache-normalized",
+            "gpt-5.3-codex",
+            {
+              turnItems: oversizedTurnItems,
+            },
+          ),
+          liveStateError: null,
+        },
+        streamEvents: tokenUsageEvents,
+      },
+      {
+        activeTab: "chat",
+        chatVisibleItemLimit: 90,
+      },
+    );
+
+    expect(normalized.readThreadState?.thread.turns[0]?.items).toHaveLength(91);
+    expect(normalized.liveState?.conversationState?.turns[0]?.items).toHaveLength(
+      91,
+    );
+    expect(normalized.streamEvents).toEqual([tokenUsageEvents[1]]);
+  });
+
   it("renders core sections", async () => {
     render(<App />);
     expect((await screen.findAllByText("Farfield")).length).toBeGreaterThan(0);
@@ -977,6 +1224,548 @@ describe("App", () => {
     expect(screen.queryByText("listed-thread-loaded")).toBeNull();
   });
 
+  it("clears a stale route-thread error after a later successful reload", async () => {
+    const threadId = "thread-recovered-route";
+    let readAttempts = 0;
+    window.history.replaceState(null, "", `/threads/${threadId}`);
+
+    readThreadResolver = (
+      targetThreadId: string,
+      provider: ProviderId | null,
+    ) => {
+      if (targetThreadId !== threadId) {
+        return null;
+      }
+
+      readAttempts += 1;
+      if (readAttempts === 1) {
+        return null;
+      }
+
+      return {
+        ok: true,
+        thread: buildConversationStateFixture(threadId, "gpt-old-codex", {
+          provider: provider ?? "codex",
+          turnItems: [
+            {
+              id: "agent-recovered-1",
+              type: "agentMessage",
+              text: "route-recovered",
+            },
+          ],
+        }),
+      };
+    };
+
+    liveStateResolver = (targetThreadId: string, provider: ProviderId) => ({
+      kind: "readLiveState",
+      threadId: targetThreadId,
+      ownerClientId: "client-1",
+      conversationState: buildConversationStateFixture(
+        targetThreadId,
+        "gpt-old-codex",
+        {
+          provider,
+          turnItems: [
+            {
+              id: "agent-recovered-1",
+              type: "agentMessage",
+              text: "route-recovered",
+            },
+          ],
+        },
+      ),
+      liveStateError: null,
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("route-recovered")).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        screen.queryByText(`Thread ${threadId} is not registered`),
+      ).toBeNull(),
+    );
+  });
+
+  it("exposes labeled trace inputs on direct debug routes", async () => {
+    const threadId = "thread-debug-route";
+    window.history.replaceState(null, "", `/threads/${threadId}/debug`);
+
+    readThreadResolver = (
+      targetThreadId: string,
+      provider: ProviderId | null,
+    ) => {
+      if (targetThreadId !== threadId) {
+        return null;
+      }
+      return {
+        ok: true,
+        thread: buildConversationStateFixture(threadId, "gpt-old-codex", {
+          provider: provider ?? "codex",
+          turnItems: [
+            {
+              id: "agent-debug-1",
+              type: "agentMessage",
+              text: "debug-route-loaded",
+            },
+          ],
+        }),
+      };
+    };
+
+    liveStateResolver = (targetThreadId: string, provider: ProviderId) => ({
+      kind: "readLiveState",
+      threadId: targetThreadId,
+      ownerClientId: "client-1",
+      conversationState: buildConversationStateFixture(
+        targetThreadId,
+        "gpt-old-codex",
+        {
+          provider,
+          turnItems: [
+            {
+              id: "agent-debug-1",
+              type: "agentMessage",
+              text: "debug-route-loaded",
+            },
+          ],
+        },
+      ),
+      liveStateError: null,
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Trace")).toBeTruthy();
+
+    const traceLabelInput = screen.getByLabelText("Trace label");
+    expect(traceLabelInput.getAttribute("name")).toBe("traceLabel");
+
+    const traceNoteInput = screen.getByLabelText("Trace marker note");
+    expect(traceNoteInput.getAttribute("name")).toBe("traceNote");
+  });
+
+  it("normalizes windows project paths and disambiguates duplicate basenames", async () => {
+    projectDirectoriesFixture = {
+      codex: [
+        "c:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+        "c:\\Users\\magon\\Documents\\Code\\Projects\\P_AgentTools",
+      ],
+      opencode: [],
+    };
+
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: "thread-agent-home-upper",
+          provider: "codex",
+          preview: "first agent home thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+        {
+          id: "thread-agent-home-lower",
+          provider: "codex",
+          preview: "second agent home thread",
+          createdAt: 1700000001,
+          updatedAt: 1700000031,
+          cwd: "c:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+        {
+          id: "thread-worktree-tools",
+          provider: "codex",
+          preview: "worktree tools thread",
+          createdAt: 1700000002,
+          updatedAt: 1700000032,
+          cwd: "C:\\Users\\magon\\.codex\\worktrees\\79d7\\P_AgentTools",
+          source: "vscode",
+        },
+        {
+          id: "thread-project-tools",
+          provider: "codex",
+          preview: "project tools thread",
+          createdAt: 1700000003,
+          updatedAt: 1700000033,
+          cwd: "c:\\Users\\magon\\Documents\\Code\\Projects\\P_AgentTools",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    render(<App />);
+
+    expect(await screen.findByText("AgentWorkingHome_P")).toBeTruthy();
+    expect(screen.getAllByText("AgentWorkingHome_P").length).toBe(1);
+    expect(screen.getAllByText("P_AgentTools").length).toBe(2);
+    expect(
+      screen.getByText("C:/Users/magon/.codex/worktrees/79d7/P_AgentTools"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("c:/Users/magon/Documents/Code/Projects/P_AgentTools"),
+    ).toBeTruthy();
+    expect(screen.getByText("History")).toBeTruthy();
+  });
+
+  it("does not mark groups as historical when the provider cannot list project directories", async () => {
+    featureMatrixFixture = {
+      ok: true,
+      features: {
+        codex: buildFeatureSet(
+          {
+            ...codexCapabilities,
+            canListProjectDirectories: false,
+          },
+          {
+            enabled: true,
+            connected: true,
+          },
+        ),
+        opencode: buildFeatureSet(opencodeCapabilities, {
+          enabled: false,
+          connected: false,
+        }),
+      },
+    };
+
+    projectDirectoriesFixture = {
+      codex: [],
+      opencode: [],
+    };
+
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: "thread-agent-home-current",
+          provider: "codex",
+          preview: "current project thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    render(<App />);
+
+    const projectButton = await screen.findByRole("button", {
+      name: /AgentWorkingHome_P/,
+    });
+    expect(projectButton.textContent ?? "").not.toContain("HISTORY");
+    expect(screen.queryByText("History")).toBeNull();
+  });
+
+  it("uses selected thread polling only as an SSE fallback in chat view", async () => {
+    const threadId = "thread-live-fallback";
+    window.history.replaceState(null, "", `/threads/${threadId}`);
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: threadId,
+          provider: "codex",
+          preview: "live fallback thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    let readThreadCallCount = 0;
+    readThreadResolver = (
+      targetThreadId: string,
+      provider: ProviderId | null,
+    ) => {
+      if (targetThreadId !== threadId) {
+        return null;
+      }
+      readThreadCallCount += 1;
+      return {
+        ok: true,
+        thread: buildConversationStateFixture(threadId, "gpt-old-codex", {
+          provider: provider ?? "codex",
+          turnItems: [
+            {
+              id: "agent-live-fallback-1",
+              type: "agentMessage",
+              text: "live-fallback-ready",
+            },
+          ],
+        }),
+      };
+    };
+    liveStateResolver = (targetThreadId: string, provider: ProviderId) => ({
+      kind: "readLiveState",
+      threadId: targetThreadId,
+      ownerClientId: "client-1",
+      conversationState: buildConversationStateFixture(
+        targetThreadId,
+        "gpt-old-codex",
+        {
+          provider,
+          turnItems: [
+            {
+              id: "agent-live-fallback-1",
+              type: "agentMessage",
+              text: "live-fallback-ready",
+            },
+          ],
+        },
+      ),
+      liveStateError: null,
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("live-fallback-ready")).toBeTruthy();
+
+    await act(async () => {
+      MockEventSource.emitOpen();
+      await new Promise((resolve) => window.setTimeout(resolve, 300));
+    });
+
+    const connectedCallCount = readThreadCallCount;
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 1400));
+    });
+
+    expect(readThreadCallCount).toBe(connectedCallCount);
+
+    await act(async () => {
+      MockEventSource.emitError();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(readThreadCallCount).toBeGreaterThan(connectedCallCount),
+    );
+  });
+
+  it("reloads a larger chat window when showing older messages", async () => {
+    const threadId = "thread-windowed-chat";
+    const turnItems: UnifiedItem[] = Array.from({ length: 95 }, (_, index) => ({
+      id: `agent-windowed-${index}`,
+      type: "agentMessage",
+      text: `windowed-message-${index}`,
+    }));
+
+    window.history.replaceState(null, "", `/threads/${threadId}`);
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: threadId,
+          provider: "codex",
+          preview: "windowed thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    let readThreadCallCount = 0;
+    readThreadResolver = (
+      targetThreadId: string,
+      provider: ProviderId | null,
+    ) => {
+      if (targetThreadId !== threadId) {
+        return null;
+      }
+      readThreadCallCount += 1;
+      return {
+        ok: true,
+        thread: buildConversationStateFixture(threadId, "gpt-old-codex", {
+          provider: provider ?? "codex",
+          turnItems,
+        }),
+      };
+    };
+    liveStateResolver = (targetThreadId: string, provider: ProviderId) => ({
+      kind: "readLiveState",
+      threadId: targetThreadId,
+      ownerClientId: "client-1",
+      conversationState: buildConversationStateFixture(
+        targetThreadId,
+        "gpt-old-codex",
+        {
+          provider,
+          turnItems,
+        },
+      ),
+      liveStateError: null,
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("windowed-message-94")).toBeTruthy();
+    expect(screen.queryByText("windowed-message-0")).toBeNull();
+    const initialReadThreadCallCount = readThreadCallCount;
+
+    fireEvent.click(await screen.findByRole("button", { name: /show older messages/i }));
+
+    expect(await screen.findByText("windowed-message-0")).toBeTruthy();
+    expect(readThreadCallCount).toBeGreaterThan(initialReadThreadCallCount);
+  });
+
+  it("ignores stale chat-window loads after a newer debug load finishes first", async () => {
+    const threadId = "thread-load-race";
+    const staleChatLoad = createDeferred<{
+      ok: true;
+      thread: UnifiedThreadFixture;
+    }>();
+    const freshDebugLoad = createDeferred<{
+      ok: true;
+      thread: UnifiedThreadFixture;
+    }>();
+
+    window.history.replaceState(null, "", `/threads/${threadId}`);
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: threadId,
+          provider: "codex",
+          preview: "race thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    readThreadResolver = (
+      targetThreadId: string,
+      provider: ProviderId | null,
+      options,
+    ) => {
+      if (targetThreadId !== threadId) {
+        return null;
+      }
+
+      if (options?.maxRenderableItems === null) {
+        return freshDebugLoad.promise;
+      }
+
+      return staleChatLoad.promise;
+    };
+    liveStateResolver = (targetThreadId: string, _provider: ProviderId) => ({
+      kind: "readLiveState",
+      threadId: targetThreadId,
+      ownerClientId: "client-1",
+      conversationState: null,
+      liveStateError: null,
+    });
+
+    render(<App />);
+
+    await act(async () => {
+      window.history.replaceState(null, "", `/threads/${threadId}/debug`);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      freshDebugLoad.resolve({
+        ok: true,
+        thread: {
+          ...buildConversationStateFixture(threadId, "gpt-old-codex", {
+            provider: "codex",
+            turnItems: [
+              {
+                id: "agent-debug-fresh-1",
+                type: "agentMessage",
+                text: "fresh-debug-state",
+              },
+            ],
+          }),
+          title: "Fresh Debug Title",
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect((await screen.findAllByText("Fresh Debug Title")).length).toBeGreaterThan(
+      0,
+    );
+
+    await act(async () => {
+      staleChatLoad.resolve({
+        ok: true,
+        thread: {
+          ...buildConversationStateFixture(threadId, "gpt-old-codex", {
+            provider: "codex",
+            turnItems: [
+              {
+                id: "agent-chat-stale-1",
+                type: "agentMessage",
+                text: "stale-chat-state",
+              },
+            ],
+          }),
+          title: "Stale Chat Title",
+        },
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("Stale Chat Title")).toBeNull(),
+    );
+    expect(screen.getAllByText("Fresh Debug Title").length).toBeGreaterThan(0);
+  });
+
   it("hides mode controls when capability is disabled", async () => {
     featureMatrixFixture = {
       ok: true,
@@ -1027,7 +1816,9 @@ describe("App", () => {
     };
 
     render(<App />);
-    expect(await screen.findByRole("button", { name: "site" })).toBeTruthy();
+    expect(
+      await screen.findByRole("button", { name: /site/ }),
+    ).toBeTruthy();
   });
 
   it("keeps manual group order over automatic recency sort", async () => {
@@ -1070,8 +1861,8 @@ describe("App", () => {
 
     render(<App />);
 
-    const projA = await screen.findByRole("button", { name: "proj-a" });
-    const projB = await screen.findByRole("button", { name: "proj-b" });
+    const projA = await screen.findByRole("button", { name: /proj-a/ });
+    const projB = await screen.findByRole("button", { name: /proj-b/ });
 
     expect(
       projB.compareDocumentPosition(projA) & Node.DOCUMENT_POSITION_FOLLOWING,

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -1651,6 +1651,74 @@ describe("App", () => {
     );
   });
 
+  it("refreshes core thread data when unified events reconnect", async () => {
+    const threadId = "thread-reconnect-core";
+
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: threadId,
+          provider: "codex",
+          preview: "preview-before-reconnect",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "/tmp/project",
+          source: "codex",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    render(<App />);
+
+    expect(
+      (await screen.findAllByText("preview-before-reconnect")).length,
+    ).toBeGreaterThan(0);
+
+    await act(async () => {
+      MockEventSource.emitOpen();
+      await new Promise((resolve) => window.setTimeout(resolve, 300));
+    });
+
+    threadsFixture = {
+      ...threadsFixture,
+      data: [
+        {
+          id: threadId,
+          provider: "codex",
+          preview: "preview-after-reconnect",
+          createdAt: 1700000000,
+          updatedAt: 1700001030,
+          cwd: "/tmp/project",
+          source: "codex",
+        },
+      ],
+    };
+
+    await act(async () => {
+      MockEventSource.emitError();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 1100));
+      MockEventSource.emitOpen();
+      await new Promise((resolve) => window.setTimeout(resolve, 300));
+    });
+
+    expect(
+      (await screen.findAllByText("preview-after-reconnect")).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("reloads a larger chat window when showing older messages", async () => {
     const threadId = "thread-windowed-chat";
     const turnItems: UnifiedItem[] = Array.from({ length: 95 }, (_, index) => ({
@@ -1725,6 +1793,92 @@ describe("App", () => {
 
     expect(await screen.findByText("windowed-message-0")).toBeTruthy();
     expect(readThreadCallCount).toBeGreaterThan(initialReadThreadCallCount);
+  });
+
+  it("does not dedupe a larger chat window when the retained head boundary moves", async () => {
+    const threadId = "thread-windowed-chat-head";
+    const olderItems: UnifiedItem[] = Array.from({ length: 95 }, (_, index) => ({
+      id: `agent-windowed-head-${index}`,
+      type: "agentMessage",
+      text: `windowed-head-message-${index}`,
+    }));
+
+    window.history.replaceState(null, "", `/threads/${threadId}`);
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: threadId,
+          provider: "codex",
+          preview: "windowed head thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    const buildThreadState = (provider: ProviderId): UnifiedThreadFixture => ({
+      ...buildConversationStateFixture(threadId, "gpt-old-codex", {
+        provider,
+      }),
+      turns: [
+        {
+          id: "turn-older",
+          status: "completed",
+          items: olderItems,
+        },
+        {
+          id: "turn-newest",
+          status: "completed",
+          items: [
+            {
+              id: "agent-windowed-tail",
+              type: "agentMessage",
+              text: "windowed-head-tail",
+            },
+          ],
+        },
+      ],
+    });
+
+    readThreadResolver = (
+      targetThreadId: string,
+      provider: ProviderId | null,
+    ) => {
+      if (targetThreadId !== threadId) {
+        return null;
+      }
+      return {
+        ok: true,
+        thread: buildThreadState(provider ?? "codex"),
+      };
+    };
+    liveStateResolver = (targetThreadId: string, provider: ProviderId) => ({
+      kind: "readLiveState",
+      threadId: targetThreadId,
+      ownerClientId: "client-1",
+      conversationState: buildThreadState(provider),
+      liveStateError: null,
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("windowed-head-tail")).toBeTruthy();
+    expect(screen.queryByText("windowed-head-message-0")).toBeNull();
+
+    fireEvent.click(await screen.findByRole("button", { name: /show older messages/i }));
+
+    expect(await screen.findByText("windowed-head-message-0")).toBeTruthy();
   });
 
   it("ignores stale chat-window loads after a newer debug load finishes first", async () => {

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -1,5 +1,10 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  UnifiedCommandReadLiveStateSchema,
+  UnifiedCommandReadThreadSchema,
+  UnifiedProviderIdSchema,
+} from "@farfield/unified-surface";
 import type {
   JsonValue,
   UnifiedFeatureAvailability,
@@ -7,6 +12,7 @@ import type {
   UnifiedItem,
   UnifiedThread,
 } from "@farfield/unified-surface";
+import { z } from "zod";
 import {
   App,
   normalizeCachedThreadViewStateForStorage,
@@ -143,6 +149,58 @@ const FEATURE_IDS: UnifiedFeatureId[] = [
 ];
 
 type ProviderId = "codex" | "opencode";
+
+function normalizeOptionalPositiveIntInput(value: unknown): unknown {
+  if (value === null || value === undefined || value === "") {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return Number(value);
+  }
+  return value;
+}
+
+function normalizeOptionalBooleanInput(value: unknown): unknown {
+  if (value === null || value === undefined || value === "") {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    if (value === "0" || value === "false") {
+      return false;
+    }
+    if (value === "1" || value === "true") {
+      return true;
+    }
+  }
+  return value;
+}
+
+const MockReadThreadRequestSchema = UnifiedCommandReadThreadSchema.extend({
+  provider: UnifiedProviderIdSchema.optional(),
+  includeTurns: z.preprocess(
+    normalizeOptionalBooleanInput,
+    z.boolean().optional().default(true),
+  ),
+  maxRenderableItems: z.preprocess(
+    normalizeOptionalPositiveIntInput,
+    z.number().int().positive().optional(),
+  ),
+}).strict();
+
+const MockUnifiedCommandEnvelopeSchema = z
+  .object({
+    kind: z.string(),
+    provider: UnifiedProviderIdSchema.default("codex"),
+    threadId: z.string().optional(),
+  })
+  .passthrough();
+
+const MockReadLiveStateCommandSchema = UnifiedCommandReadLiveStateSchema.extend({
+  maxRenderableItems: z.preprocess(
+    normalizeOptionalPositiveIntInput,
+    z.number().int().positive().optional(),
+  ),
+}).strict();
 
 type CapabilityFixture = {
   canListModels: boolean;
@@ -548,6 +606,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.clearAllTimers();
   vi.useRealTimers();
 });
 
@@ -593,25 +652,21 @@ vi.stubGlobal(
         .split("/")
         .filter((segment) => segment.length > 0);
       const threadId = segments[3] ? decodeURIComponent(segments[3]) : "";
-      const providerParam = parsedUrl.searchParams.get("provider");
-      const provider =
-        providerParam === "opencode" || providerParam === "codex"
-          ? providerParam
-          : null;
-      const maxRenderableItemsParam =
-        parsedUrl.searchParams.get("maxRenderableItems");
-      const maxRenderableItems =
-        maxRenderableItemsParam !== null
-          ? Number(maxRenderableItemsParam)
-          : null;
-      const readThread = await readThreadResolver(threadId, provider, {
-        includeTurns: parsedUrl.searchParams.get("includeTurns") !== "false",
-        maxRenderableItems:
-          typeof maxRenderableItems === "number" &&
-          Number.isFinite(maxRenderableItems)
-            ? maxRenderableItems
-            : null,
+      const readThreadRequest = MockReadThreadRequestSchema.parse({
+        kind: "readThread",
+        provider: parsedUrl.searchParams.get("provider") ?? undefined,
+        threadId,
+        includeTurns: parsedUrl.searchParams.get("includeTurns"),
+        maxRenderableItems: parsedUrl.searchParams.get("maxRenderableItems"),
       });
+      const readThread = await readThreadResolver(
+        readThreadRequest.threadId,
+        readThreadRequest.provider ?? null,
+        {
+          includeTurns: readThreadRequest.includeTurns,
+          maxRenderableItems: readThreadRequest.maxRenderableItems ?? null,
+        },
+      );
       if (readThread) {
         return jsonResponse(readThread);
       }
@@ -625,13 +680,10 @@ vi.stubGlobal(
     }
 
     if (pathname === "/api/unified/command") {
-      const body = init?.body
-        ? (JSON.parse(String(init.body)) as {
-            kind: string;
-            provider: ProviderId;
-            threadId?: string;
-          })
+      const rawBody = init?.body
+        ? JSON.parse(String(init.body))
         : { kind: "unknown", provider: "codex" as const };
+      const body = MockUnifiedCommandEnvelopeSchema.parse(rawBody);
 
       if (body.kind === "listProjectDirectories") {
         return jsonResponse({
@@ -664,19 +716,18 @@ vi.stubGlobal(
       }
 
       if (body.kind === "readLiveState") {
-        const maxRenderableItems =
-          "maxRenderableItems" in body &&
-          typeof body.maxRenderableItems === "number" &&
-          Number.isFinite(body.maxRenderableItems)
-            ? body.maxRenderableItems
-            : undefined;
+        const readLiveStateCommand =
+          MockReadLiveStateCommandSchema.parse(rawBody);
         return jsonResponse({
           ok: true,
           result: await liveStateResolver(
-            body.threadId ?? "",
-            body.provider,
-            maxRenderableItems !== undefined
-              ? { maxRenderableItems }
+            readLiveStateCommand.threadId,
+            readLiveStateCommand.provider,
+            readLiveStateCommand.maxRenderableItems !== undefined
+              ? {
+                  maxRenderableItems:
+                    readLiveStateCommand.maxRenderableItems,
+                }
               : undefined,
           ),
         });
@@ -1627,16 +1678,17 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("live-fallback-ready")).toBeTruthy();
+    vi.useFakeTimers();
 
     await act(async () => {
       MockEventSource.emitOpen();
-      await new Promise((resolve) => window.setTimeout(resolve, 300));
+      await vi.advanceTimersByTimeAsync(300);
     });
 
     const connectedCallCount = readThreadCallCount;
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 1400));
+      await vi.advanceTimersByTimeAsync(1400);
     });
 
     expect(readThreadCallCount).toBe(connectedCallCount);
@@ -1644,11 +1696,12 @@ describe("App", () => {
     await act(async () => {
       MockEventSource.emitError();
       await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1100);
     });
 
-    await waitFor(() =>
-      expect(readThreadCallCount).toBeGreaterThan(connectedCallCount),
-    );
+    expect(readThreadCallCount).toBeGreaterThan(connectedCallCount);
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it("refreshes core thread data when unified events reconnect", async () => {

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -348,6 +348,9 @@ let readThreadResolver: (
 let liveStateResolver: (
   threadId: string,
   provider: ProviderId,
+  options?: {
+    maxRenderableItems?: number;
+  },
 ) => MaybePromise<{
   kind: "readLiveState";
   threadId: string;
@@ -530,13 +533,17 @@ beforeEach(() => {
 
   readThreadResolver = (_threadId: string, _provider: ProviderId | null) =>
     null;
-  liveStateResolver = (threadId: string, _provider: ProviderId) => ({
-    kind: "readLiveState",
-    threadId,
-    ownerClientId: null,
-    conversationState: null,
-    liveStateError: null,
-  });
+  liveStateResolver = (
+    threadId: string,
+    _provider: ProviderId,
+    _options?: { maxRenderableItems?: number },
+  ) => ({
+      kind: "readLiveState" as const,
+      threadId,
+      ownerClientId: null,
+      conversationState: null,
+      liveStateError: null,
+    });
 });
 
 afterEach(() => {
@@ -657,9 +664,21 @@ vi.stubGlobal(
       }
 
       if (body.kind === "readLiveState") {
+        const maxRenderableItems =
+          "maxRenderableItems" in body &&
+          typeof body.maxRenderableItems === "number" &&
+          Number.isFinite(body.maxRenderableItems)
+            ? body.maxRenderableItems
+            : undefined;
         return jsonResponse({
           ok: true,
-          result: await liveStateResolver(body.threadId ?? "", body.provider),
+          result: await liveStateResolver(
+            body.threadId ?? "",
+            body.provider,
+            maxRenderableItems !== undefined
+              ? { maxRenderableItems }
+              : undefined,
+          ),
         });
       }
 
@@ -1349,8 +1368,8 @@ describe("App", () => {
   it("normalizes windows project paths and disambiguates duplicate basenames", async () => {
     projectDirectoriesFixture = {
       codex: [
-        "c:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
-        "c:\\Users\\magon\\Documents\\Code\\Projects\\P_AgentTools",
+        "c:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+        "c:\\Users\\testuser\\Documents\\Code\\Projects\\P_AgentTools",
       ],
       opencode: [],
     };
@@ -1364,7 +1383,7 @@ describe("App", () => {
           preview: "first agent home thread",
           createdAt: 1700000000,
           updatedAt: 1700000030,
-          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
           source: "vscode",
         },
         {
@@ -1373,7 +1392,7 @@ describe("App", () => {
           preview: "second agent home thread",
           createdAt: 1700000001,
           updatedAt: 1700000031,
-          cwd: "c:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          cwd: "c:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
           source: "vscode",
         },
         {
@@ -1382,7 +1401,7 @@ describe("App", () => {
           preview: "worktree tools thread",
           createdAt: 1700000002,
           updatedAt: 1700000032,
-          cwd: "C:\\Users\\magon\\.codex\\worktrees\\79d7\\P_AgentTools",
+          cwd: "C:\\Users\\testuser\\.codex\\worktrees\\79d7\\P_AgentTools",
           source: "vscode",
         },
         {
@@ -1391,7 +1410,7 @@ describe("App", () => {
           preview: "project tools thread",
           createdAt: 1700000003,
           updatedAt: 1700000033,
-          cwd: "c:\\Users\\magon\\Documents\\Code\\Projects\\P_AgentTools",
+          cwd: "c:\\Users\\testuser\\Documents\\Code\\Projects\\P_AgentTools",
           source: "vscode",
         },
       ],
@@ -1411,10 +1430,10 @@ describe("App", () => {
     expect(screen.getAllByText("AgentWorkingHome_P").length).toBe(1);
     expect(screen.getAllByText("P_AgentTools").length).toBe(2);
     expect(
-      screen.getByText("C:/Users/magon/.codex/worktrees/79d7/P_AgentTools"),
+      screen.getByText("C:/Users/testuser/.codex/worktrees/79d7/P_AgentTools"),
     ).toBeTruthy();
     expect(
-      screen.getByText("c:/Users/magon/Documents/Code/Projects/P_AgentTools"),
+      screen.getByText("c:/Users/testuser/Documents/Code/Projects/P_AgentTools"),
     ).toBeTruthy();
     expect(screen.getByText("History")).toBeTruthy();
   });
@@ -1454,7 +1473,7 @@ describe("App", () => {
           preview: "current project thread",
           createdAt: 1700000000,
           updatedAt: 1700000030,
-          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
           source: "vscode",
         },
       ],
@@ -1477,6 +1496,64 @@ describe("App", () => {
     expect(screen.queryByText("History")).toBeNull();
   });
 
+  it("clears the History badge when a merged project group includes a current thread", async () => {
+    featureMatrixFixture = {
+      ok: true,
+      features: {
+        codex: buildFeatureSet(codexCapabilities, {
+          enabled: true,
+          connected: true,
+        }),
+        opencode: buildFeatureSet(opencodeCapabilities, {
+          enabled: true,
+          connected: true,
+        }),
+      },
+    };
+
+    projectDirectoriesFixture = {
+      codex: [],
+      opencode: ["c:\\Users\\testuser\\Documents\\Code\\Projects\\P_AgentTools"],
+    };
+
+    threadsFixture = {
+      ok: true,
+      data: [
+        {
+          id: "thread-tools-history",
+          provider: "codex",
+          preview: "historical tools thread",
+          createdAt: 1700000000,
+          updatedAt: 1700000030,
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\P_AgentTools",
+          source: "vscode",
+        },
+        {
+          id: "thread-tools-current",
+          provider: "opencode",
+          preview: "current tools thread",
+          createdAt: 1700000001,
+          updatedAt: 1700000031,
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\P_AgentTools",
+          source: "vscode",
+        },
+      ],
+      cursors: {
+        codex: null,
+        opencode: null,
+      },
+      errors: {
+        codex: null,
+        opencode: null,
+      },
+    };
+
+    render(<App />);
+
+    expect((await screen.findAllByText("P_AgentTools")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("History")).toBeNull();
+  });
+
   it("uses selected thread polling only as an SSE fallback in chat view", async () => {
     const threadId = "thread-live-fallback";
     window.history.replaceState(null, "", `/threads/${threadId}`);
@@ -1489,7 +1566,7 @@ describe("App", () => {
           preview: "live fallback thread",
           createdAt: 1700000000,
           updatedAt: 1700000030,
-          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
           source: "vscode",
         },
       ],
@@ -1592,7 +1669,7 @@ describe("App", () => {
           preview: "windowed thread",
           createdAt: 1700000000,
           updatedAt: 1700000030,
-          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
           source: "vscode",
         },
       ],
@@ -1671,7 +1748,7 @@ describe("App", () => {
           preview: "race thread",
           createdAt: 1700000000,
           updatedAt: 1700000030,
-          cwd: "C:\\Users\\magon\\Documents\\Code\\Projects\\AgentWorkingHome_P",
+          cwd: "C:\\Users\\testuser\\Documents\\Code\\Projects\\AgentWorkingHome_P",
           source: "vscode",
         },
       ],

--- a/apps/web/test/conversation-item.test.tsx
+++ b/apps/web/test/conversation-item.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { UnifiedItem } from "@farfield/unified-surface";
+import { ConversationItem } from "../src/components/ConversationItem.js";
+
+function renderConversationItem(item: UnifiedItem) {
+  return render(
+    <ConversationItem
+      item={item}
+      isLast={false}
+      turnIsInProgress={false}
+      onSelectThread={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConversationItem", () => {
+  it("renders user messages with both text and images", () => {
+    renderConversationItem({
+      id: "user-with-image",
+      type: "userMessage",
+      content: [
+        { type: "text", text: "please inspect this screenshot" },
+        { type: "image", url: "https://example.com/screenshot.png" },
+      ],
+    });
+
+    expect(screen.getByText("please inspect this screenshot")).toBeTruthy();
+    expect(screen.getByText("User image 1")).toBeTruthy();
+    expect(screen.getByText("https://example.com/screenshot.png")).toBeTruthy();
+  });
+
+  it("renders image-only steering messages", () => {
+    renderConversationItem({
+      id: "steering-image-only",
+      type: "steeringUserMessage",
+      content: [
+        { type: "image", url: "https://example.com/diagram.png" },
+      ],
+    });
+
+    expect(screen.getByText("User image 1")).toBeTruthy();
+    expect(screen.getByText("https://example.com/diagram.png")).toBeTruthy();
+  });
+
+  it("ignores empty user-message content", () => {
+    const { container } = renderConversationItem({
+      id: "user-empty-content",
+      type: "userMessage",
+      content: [
+        { type: "text", text: "" },
+        { type: "image", url: "   " },
+      ],
+    });
+
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByText("User image 1")).toBeNull();
+  });
+});

--- a/packages/codex-api/src/app-server-client.ts
+++ b/packages/codex-api/src/app-server-client.ts
@@ -26,7 +26,6 @@ import {
   ChildProcessAppServerTransport,
   type ChildProcessAppServerTransportOptions
 } from "./app-server-transport.js";
-import { AppServerRpcError } from "./errors.js";
 
 function parseWithSchema<T>(
   schema: z.ZodType<T, z.ZodTypeDef, unknown>,
@@ -40,16 +39,40 @@ function parseWithSchema<T>(
   return parsed.data;
 }
 
-function isUnsupportedThreadReadRpcError(error: unknown): error is AppServerRpcError {
-  if (!(error instanceof AppServerRpcError)) {
+const ThreadReadRpcErrorDataSchema = z
+  .object({
+    action: z.string().optional(),
+    method: z.string().optional(),
+    variant: z.string().optional()
+  })
+  .passthrough();
+
+const AppServerRpcErrorLikeSchema = z
+  .object({
+    code: z.number(),
+    data: z.unknown().optional(),
+    message: z.string()
+  })
+  .passthrough();
+
+function isUnsupportedThreadReadRpcError(error: unknown): boolean {
+  const parsedError = AppServerRpcErrorLikeSchema.safeParse(error);
+  if (!parsedError.success || parsedError.data.code !== -32600) {
     return false;
   }
 
-  if (error.code !== -32600) {
-    return false;
+  const parsedData = ThreadReadRpcErrorDataSchema.safeParse(parsedError.data.data);
+  if (parsedData.success) {
+    const method = parsedData.data.method ?? parsedData.data.action;
+    if (
+      method === "thread/read" &&
+      parsedData.data.variant?.toLowerCase() === "unknown"
+    ) {
+      return true;
+    }
   }
 
-  const normalized = error.message.toLowerCase();
+  const normalized = parsedError.data.message.toLowerCase();
   return normalized.includes("unknown variant") && normalized.includes("thread/read");
 }
 

--- a/packages/codex-api/src/app-server-client.ts
+++ b/packages/codex-api/src/app-server-client.ts
@@ -26,6 +26,7 @@ import {
   ChildProcessAppServerTransport,
   type ChildProcessAppServerTransportOptions
 } from "./app-server-transport.js";
+import { AppServerRpcError } from "./errors.js";
 
 function parseWithSchema<T>(
   schema: z.ZodType<T, z.ZodTypeDef, unknown>,
@@ -37,6 +38,19 @@ function parseWithSchema<T>(
     throw ProtocolValidationError.fromZod(context, parsed.error);
   }
   return parsed.data;
+}
+
+function isUnsupportedThreadReadRpcError(error: unknown): error is AppServerRpcError {
+  if (!(error instanceof AppServerRpcError)) {
+    return false;
+  }
+
+  if (error.code !== -32600) {
+    return false;
+  }
+
+  const normalized = error.message.toLowerCase();
+  return normalized.includes("unknown variant") && normalized.includes("thread/read");
 }
 
 export interface ListThreadsOptions {
@@ -190,12 +204,33 @@ export class AppServerClient {
   }
 
   public async readThread(threadId: string, includeTurns = true): Promise<AppServerReadThreadResponse> {
-    const result = await this.transport.request("thread/read", {
-      threadId,
-      includeTurns
-    });
+    try {
+      const result = await this.transport.request("thread/read", {
+        threadId,
+        includeTurns
+      });
 
-    return parseWithSchema(AppServerReadThreadResponseSchema, result, "AppServerReadThreadResponse");
+      return parseWithSchema(AppServerReadThreadResponseSchema, result, "AppServerReadThreadResponse");
+    } catch (error) {
+      if (!isUnsupportedThreadReadRpcError(error)) {
+        throw error;
+      }
+
+      const resumed = await this.resumeThread(threadId, {
+        persistExtendedHistory: includeTurns
+      });
+      if (includeTurns) {
+        return resumed;
+      }
+
+      return {
+        ...resumed,
+        thread: {
+          ...resumed.thread,
+          turns: []
+        }
+      };
+    }
   }
 
   public async listModels(limit = 100): Promise<AppServerListModelsResponse> {

--- a/packages/codex-api/src/app-server-transport.ts
+++ b/packages/codex-api/src/app-server-transport.ts
@@ -76,7 +76,7 @@ function quoteCmdArg(value: string): string {
   if (value.length === 0) {
     return '""';
   }
-  if (!/[\s"]/.test(value)) {
+  if (!/[\s"&|^<>()]/.test(value)) {
     return value;
   }
   return `"${value.replace(/"/g, '""')}"`;

--- a/packages/codex-api/src/app-server-transport.ts
+++ b/packages/codex-api/src/app-server-transport.ts
@@ -1,6 +1,8 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import readline from "node:readline";
 import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import type { AppServerClientRequestMethod } from "@farfield/protocol";
 import {
   AppServerRpcError,
@@ -31,6 +33,98 @@ export interface ChildProcessAppServerTransportOptions {
   onStderr?: (line: string) => void;
 }
 
+interface SpawnSpec {
+  command: string;
+  args: string[];
+}
+
+function buildCodexNpmShimSpawnSpec(
+  executablePath: string,
+  args: string[]
+): SpawnSpec | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  const ext = path.extname(executablePath).toLowerCase();
+  const baseName = path.basename(executablePath, ext).toLowerCase();
+  if (baseName !== "codex" || (ext !== ".cmd" && ext !== ".ps1")) {
+    return null;
+  }
+
+  const shimDir = path.dirname(executablePath);
+  const scriptPath = path.join(
+    shimDir,
+    "node_modules",
+    "@openai",
+    "codex",
+    "bin",
+    "codex.js"
+  );
+  if (!fs.existsSync(scriptPath)) {
+    return null;
+  }
+
+  const bundledNode = path.join(shimDir, "node.exe");
+  return {
+    command: fs.existsSync(bundledNode) ? bundledNode : "node",
+    args: [scriptPath, ...args]
+  };
+}
+
+function quoteCmdArg(value: string): string {
+  if (value.length === 0) {
+    return '""';
+  }
+  if (!/[\s"]/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function buildSpawnSpec(executablePath: string, args: string[]): SpawnSpec {
+  const codexShimSpec = buildCodexNpmShimSpawnSpec(executablePath, args);
+  if (codexShimSpec) {
+    return codexShimSpec;
+  }
+
+  if (process.platform !== "win32") {
+    return {
+      command: executablePath,
+      args
+    };
+  }
+
+  const ext = path.extname(executablePath).toLowerCase();
+  if (ext === ".ps1") {
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        executablePath,
+        ...args
+      ]
+    };
+  }
+
+  if (ext === ".cmd" || ext === ".bat") {
+    const comspec = process.env["ComSpec"] || "cmd.exe";
+    const commandLine = [quoteCmdArg(executablePath), ...args.map(quoteCmdArg)].join(" ");
+    return {
+      command: comspec,
+      args: ["/d", "/s", "/c", commandLine]
+    };
+  }
+
+  return {
+    command: executablePath,
+    args
+  };
+}
+
 export class ChildProcessAppServerTransport implements AppServerTransport {
   private readonly executablePath: string;
   private readonly userAgent: string;
@@ -58,7 +152,8 @@ export class ChildProcessAppServerTransport implements AppServerTransport {
       return;
     }
 
-    const child = spawn(this.executablePath, ["app-server"], {
+    const spawnSpec = buildSpawnSpec(this.executablePath, ["app-server"]);
+    const child = spawn(spawnSpec.command, spawnSpec.args, {
       cwd: this.cwd,
       env: {
         ...process.env,

--- a/packages/codex-api/src/app-server-transport.ts
+++ b/packages/codex-api/src/app-server-transport.ts
@@ -1,4 +1,8 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  execFileSync,
+  spawn,
+  type ChildProcessWithoutNullStreams
+} from "node:child_process";
 import readline from "node:readline";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
@@ -38,21 +42,71 @@ interface SpawnSpec {
   args: string[];
 }
 
-function buildCodexNpmShimSpawnSpec(
-  executablePath: string,
-  args: string[]
-): SpawnSpec | null {
+function resolveWindowsCommandOnPath(command: string): string | null {
+  try {
+    return (
+      execFileSync("where.exe", [command], {
+        encoding: "utf8"
+      })
+        .split(/\r?\n/)
+        .map((entry) => entry.trim())
+        .find((entry) => entry.length > 0) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function resolveWindowsCodexExecutablePath(executablePath: string): string | null {
   if (process.platform !== "win32") {
     return null;
   }
 
   const ext = path.extname(executablePath).toLowerCase();
   const baseName = path.basename(executablePath, ext).toLowerCase();
-  if (baseName !== "codex" || (ext !== ".cmd" && ext !== ".ps1")) {
+  if (baseName !== "codex") {
     return null;
   }
 
-  const shimDir = path.dirname(executablePath);
+  if (ext === ".cmd" || ext === ".ps1" || ext === ".bat") {
+    return executablePath;
+  }
+  if (ext.length > 0) {
+    return null;
+  }
+
+  const siblingCandidates = [`${executablePath}.cmd`, `${executablePath}.ps1`];
+  for (const candidate of siblingCandidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  if (!/[\\/]/.test(executablePath)) {
+    return (
+      resolveWindowsCommandOnPath("codex.cmd") ??
+      resolveWindowsCommandOnPath("codex.ps1")
+    );
+  }
+
+  return null;
+}
+
+export function buildCodexNpmShimSpawnSpec(
+  executablePath: string,
+  args: string[]
+): SpawnSpec | null {
+  const resolvedExecutablePath = resolveWindowsCodexExecutablePath(executablePath);
+  if (!resolvedExecutablePath) {
+    return null;
+  }
+
+  const ext = path.extname(resolvedExecutablePath).toLowerCase();
+  if (ext !== ".cmd" && ext !== ".ps1") {
+    return null;
+  }
+
+  const shimDir = path.dirname(resolvedExecutablePath);
   const scriptPath = path.join(
     shimDir,
     "node_modules",
@@ -82,7 +136,7 @@ function quoteCmdArg(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-function buildSpawnSpec(executablePath: string, args: string[]): SpawnSpec {
+export function buildSpawnSpec(executablePath: string, args: string[]): SpawnSpec {
   const codexShimSpec = buildCodexNpmShimSpawnSpec(executablePath, args);
   if (codexShimSpec) {
     return codexShimSpec;
@@ -95,7 +149,9 @@ function buildSpawnSpec(executablePath: string, args: string[]): SpawnSpec {
     };
   }
 
-  const ext = path.extname(executablePath).toLowerCase();
+  const resolvedExecutablePath =
+    resolveWindowsCodexExecutablePath(executablePath) ?? executablePath;
+  const ext = path.extname(resolvedExecutablePath).toLowerCase();
   if (ext === ".ps1") {
     return {
       command: "powershell.exe",
@@ -104,7 +160,7 @@ function buildSpawnSpec(executablePath: string, args: string[]): SpawnSpec {
         "-ExecutionPolicy",
         "Bypass",
         "-File",
-        executablePath,
+        resolvedExecutablePath,
         ...args
       ]
     };
@@ -112,7 +168,7 @@ function buildSpawnSpec(executablePath: string, args: string[]): SpawnSpec {
 
   if (ext === ".cmd" || ext === ".bat") {
     const comspec = process.env["ComSpec"] || "cmd.exe";
-    const commandLine = [quoteCmdArg(executablePath), ...args.map(quoteCmdArg)].join(" ");
+    const commandLine = [quoteCmdArg(resolvedExecutablePath), ...args.map(quoteCmdArg)].join(" ");
     return {
       command: comspec,
       args: ["/d", "/s", "/c", commandLine]

--- a/packages/codex-api/test/app-server-client.test.ts
+++ b/packages/codex-api/test/app-server-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { AppServerClient } from "../src/app-server-client.js";
 import type { AppServerTransport } from "../src/app-server-transport.js";
+import { AppServerRpcError } from "../src/errors.js";
 
 const START_THREAD_RESPONSE = {
   thread: {
@@ -113,6 +114,90 @@ describe("AppServerClient.resumeThread", () => {
       threadId: "thread-1",
       persistExtendedHistory: true
     });
+  });
+});
+
+describe("AppServerClient.readThread", () => {
+  it("falls back to thread/resume when thread/read is unsupported", async () => {
+    const transport: AppServerTransport = {
+      request: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new AppServerRpcError(
+            -32600,
+            "Invalid request: unknown variant `thread/read`, expected one of `thread/resume`"
+          )
+        )
+        .mockResolvedValueOnce({
+          thread: {
+            id: "thread-1",
+            turns: [
+              {
+                id: "turn-1",
+                status: "completed",
+                items: []
+              }
+            ],
+            requests: []
+          }
+        }),
+      respond: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const client = new AppServerClient(transport);
+    const result = await client.readThread("thread-1");
+
+    expect(transport.request).toHaveBeenNthCalledWith(1, "thread/read", {
+      threadId: "thread-1",
+      includeTurns: true
+    });
+    expect(transport.request).toHaveBeenNthCalledWith(2, "thread/resume", {
+      threadId: "thread-1",
+      persistExtendedHistory: true
+    });
+    expect(result.thread.turns).toHaveLength(1);
+  });
+
+  it("drops turns when thread/read fallback is used without includeTurns", async () => {
+    const transport: AppServerTransport = {
+      request: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new AppServerRpcError(
+            -32600,
+            "Invalid request: unknown variant `thread/read`, expected one of `thread/resume`"
+          )
+        )
+        .mockResolvedValueOnce({
+          thread: {
+            id: "thread-1",
+            turns: [
+              {
+                id: "turn-1",
+                status: "completed",
+                items: []
+              }
+            ],
+            requests: []
+          }
+        }),
+      respond: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const client = new AppServerClient(transport);
+    const result = await client.readThread("thread-1", false);
+
+    expect(transport.request).toHaveBeenNthCalledWith(1, "thread/read", {
+      threadId: "thread-1",
+      includeTurns: false
+    });
+    expect(transport.request).toHaveBeenNthCalledWith(2, "thread/resume", {
+      threadId: "thread-1",
+      persistExtendedHistory: false
+    });
+    expect(result.thread.turns).toEqual([]);
   });
 });
 

--- a/packages/codex-api/test/app-server-transport.test.ts
+++ b/packages/codex-api/test/app-server-transport.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(
+  process,
+  "platform",
+);
+
+function setWindowsPlatform(): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: "win32",
+  });
+}
+
+describe("buildSpawnSpec", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("node:child_process");
+    if (ORIGINAL_PLATFORM_DESCRIPTOR) {
+      Object.defineProperty(process, "platform", ORIGINAL_PLATFORM_DESCRIPTOR);
+    }
+  });
+
+  it("routes extensionless Codex paths through a sibling cmd shim on Windows", async () => {
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      spawn: vi.fn(),
+    }));
+
+    setWindowsPlatform();
+    const temporaryDirectory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "farfield-codex-shim-"),
+    );
+    const executablePath = path.join(temporaryDirectory, "codex");
+    await fs.promises.writeFile(`${executablePath}.cmd`, "@echo off\r\n", "utf8");
+
+    try {
+      const { buildSpawnSpec } = await import(
+        "../src/app-server-transport.js"
+      );
+      const spawnSpec = buildSpawnSpec(executablePath, ["app-server"]);
+
+      expect(spawnSpec.command).toBe(process.env["ComSpec"] || "cmd.exe");
+      expect(spawnSpec.args[3]).toContain(`${executablePath}.cmd`);
+    } finally {
+      await fs.promises.rm(temporaryDirectory, {
+        recursive: true,
+        force: true,
+      });
+    }
+  });
+
+  it("routes bare Codex commands through where.exe lookup before spawning on Windows", async () => {
+    const execFileSync = vi.fn(() => "C:\\Tools\\codex.cmd\r\n");
+    vi.doMock("node:child_process", () => ({
+      execFileSync,
+      spawn: vi.fn(),
+    }));
+
+    setWindowsPlatform();
+    const { buildSpawnSpec } = await import("../src/app-server-transport.js");
+    const spawnSpec = buildSpawnSpec("codex", ["app-server"]);
+
+    expect(execFileSync).toHaveBeenCalledWith("where.exe", ["codex.cmd"], {
+      encoding: "utf8",
+    });
+    expect(spawnSpec.command).toBe(process.env["ComSpec"] || "cmd.exe");
+    expect(spawnSpec.args[3]).toContain("C:\\Tools\\codex.cmd");
+  });
+});

--- a/packages/codex-protocol/scripts/generate-app-server-zod.mjs
+++ b/packages/codex-protocol/scripts/generate-app-server-zod.mjs
@@ -103,6 +103,10 @@ const methodManifestSources = {
   ]
 };
 
+function toPosixRelative(filePath) {
+  return path.relative(root, filePath).split(path.sep).join("/");
+}
+
 function ensureSchemaFilesExist() {
   const missing = schemaTargets.filter((target) => !fs.existsSync(target.source));
   const missingManifestSources = Object.entries(methodManifestSources)
@@ -144,7 +148,7 @@ async function writeSchemaModule(target) {
 
   const withHeader = [
     "// GENERATED FILE. DO NOT EDIT.",
-    `// Source: ${path.relative(root, target.source)}`,
+    `// Source: ${toPosixRelative(target.source)}`,
     generated.trim(),
     ""
   ].join("\n");
@@ -194,10 +198,10 @@ function writeMethodManifestModule() {
 
   const lines = [
     "// GENERATED FILE. DO NOT EDIT.",
-    ...methodManifestSources.clientRequest.map((source) => `// Source: ${path.relative(root, source)}`),
-    ...methodManifestSources.clientNotification.map((source) => `// Source: ${path.relative(root, source)}`),
-    ...methodManifestSources.serverRequest.map((source) => `// Source: ${path.relative(root, source)}`),
-    ...methodManifestSources.serverNotification.map((source) => `// Source: ${path.relative(root, source)}`),
+    ...methodManifestSources.clientRequest.map((source) => `// Source: ${toPosixRelative(source)}`),
+    ...methodManifestSources.clientNotification.map((source) => `// Source: ${toPosixRelative(source)}`),
+    ...methodManifestSources.serverRequest.map((source) => `// Source: ${toPosixRelative(source)}`),
+    ...methodManifestSources.serverNotification.map((source) => `// Source: ${toPosixRelative(source)}`),
     "",
     renderStringTuple("APP_SERVER_CLIENT_REQUEST_METHODS", clientRequestMethods),
     "export type AppServerClientRequestMethod =",

--- a/packages/codex-protocol/src/app-server.ts
+++ b/packages/codex-protocol/src/app-server.ts
@@ -40,6 +40,38 @@ const AppServerModelReasoningEffortItemSchema = z
   })
   .passthrough();
 
+const AppServerThreadStatusActiveFlagSchema = z.enum([
+  "waitingOnApproval",
+  "waitingOnUserInput"
+]);
+
+const AppServerThreadStatusSchema = z.union([
+  z
+    .object({
+      type: z.literal("active"),
+      activeFlags: z.array(AppServerThreadStatusActiveFlagSchema)
+    })
+    .passthrough(),
+  z.object({ type: z.literal("idle") }).passthrough(),
+  z.object({ type: z.literal("notLoaded") }).passthrough(),
+  z.object({ type: z.literal("systemError") }).passthrough()
+]);
+
+const AppServerModelInputModalitySchema = z.enum(["text", "image"]);
+const AppServerModelUpgradeInfoSchema = z
+  .object({
+    migrationMarkdown: z.union([z.string(), z.null()]).optional(),
+    model: z.string(),
+    modelLink: z.union([z.string(), z.null()]).optional(),
+    upgradeCopy: z.union([z.string(), z.null()]).optional()
+  })
+  .passthrough();
+const AppServerModelAvailabilityNuxSchema = z
+  .object({
+    message: z.string()
+  })
+  .passthrough();
+
 const AppServerGeneratedThreadListItemSchema = z
   .object({
     id: z.string().min(1),
@@ -50,13 +82,13 @@ const AppServerGeneratedThreadListItemSchema = z
     createdAt: z.number().int().nonnegative(),
     updatedAt: z.number().int().nonnegative(),
     cwd: z.string().optional(),
-    source: z.any().optional(),
+    source: ThreadConversationStateSchema.shape.source,
     modelProvider: z.string().optional(),
     cliVersion: z.string().optional(),
     path: z.union([z.string(), z.null()]).optional(),
-    gitInfo: z.any().optional(),
-    status: z.any().optional(),
-    turns: z.array(z.any()).optional()
+    gitInfo: ThreadConversationStateSchema.shape.gitInfo,
+    status: AppServerThreadStatusSchema.optional(),
+    turns: ThreadConversationStateSchema.shape.turns.optional()
   })
   .passthrough();
 
@@ -78,7 +110,15 @@ export const AppServerThreadListItemSchema = z.union([
   OpenCodeThreadListItemSchema
 ]);
 
-export const AppServerListThreadsResponseSchema = z
+export const AppServerListThreadsResponseSchema: z.ZodObject<
+  {
+    data: z.ZodArray<typeof AppServerThreadListItemSchema>;
+    nextCursor: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
+    pages: z.ZodOptional<z.ZodNumber>;
+    truncated: z.ZodOptional<z.ZodBoolean>;
+  },
+  "passthrough"
+> = z
   .object({
     data: z.array(AppServerThreadListItemSchema),
     nextCursor: z.union([z.string(), z.null()]).optional(),
@@ -107,12 +147,12 @@ export const AppServerModelSchema = z
     hidden: z.boolean().optional(),
     supportedReasoningEfforts: z.array(AppServerModelReasoningEffortItemSchema).default([]),
     defaultReasoningEffort: z.string().optional(),
-    inputModalities: z.array(z.any()).optional(),
+    inputModalities: z.array(AppServerModelInputModalitySchema).optional(),
     supportsPersonality: z.boolean().optional(),
     isDefault: z.boolean().optional(),
     upgrade: z.union([z.string(), z.null()]).optional(),
-    upgradeInfo: z.any().optional(),
-    availabilityNux: z.any().optional()
+    upgradeInfo: z.union([AppServerModelUpgradeInfoSchema, z.null()]).optional(),
+    availabilityNux: z.union([AppServerModelAvailabilityNuxSchema, z.null()]).optional()
   })
   .passthrough();
 
@@ -153,7 +193,18 @@ export const AppServerCollaborationModeListResponseSchema = z
 
 export const AppServerStartThreadRequestSchema = AppServerStartThreadRequestBaseSchema;
 
-export const AppServerStartThreadResponseSchema = z
+export const AppServerStartThreadResponseSchema: z.ZodObject<
+  {
+    thread: typeof AppServerThreadListItemSchema;
+    model: z.ZodOptional<z.ZodString>;
+    modelProvider: z.ZodOptional<z.ZodString>;
+    cwd: z.ZodOptional<z.ZodString>;
+    approvalPolicy: z.ZodOptional<z.ZodString>;
+    sandbox: z.ZodOptional<z.ZodAny>;
+    reasoningEffort: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
+  },
+  "passthrough"
+> = z
   .object({
     thread: AppServerThreadListItemSchema,
     model: z.string().optional(),

--- a/packages/codex-protocol/src/app-server.ts
+++ b/packages/codex-protocol/src/app-server.ts
@@ -23,8 +23,6 @@ import {
 const AppServerThreadListResponseBaseSchema = GeneratedThreadListResponseSchema.passthrough();
 const AppServerThreadReadResponseBaseSchema = GeneratedThreadReadResponseSchema.passthrough();
 const AppServerModelListResponseBaseSchema = GeneratedModelListResponseSchema.passthrough();
-const AppServerCollaborationModeListResponseBaseSchema =
-  GeneratedCollaborationModeListResponseSchema.passthrough();
 const AppServerGetAccountRateLimitsResponseBaseSchema =
   GeneratedGetAccountRateLimitsResponseSchema.passthrough();
 const AppServerStartThreadRequestBaseSchema = GeneratedThreadStartParamsSchema.passthrough();
@@ -35,11 +33,32 @@ const AppServerServerRequestBaseSchema = z.union([
 
 const ThreadTitleSchema = z.union([z.string(), z.null()]).optional();
 const ThreadIsGeneratingSchema = z.boolean().optional();
+const AppServerModelReasoningEffortItemSchema = z
+  .object({
+    reasoningEffort: z.string(),
+    description: z.string().optional()
+  })
+  .passthrough();
 
-const AppServerGeneratedThreadListItemSchema = AppServerThreadListResponseBaseSchema.shape.data.element.extend({
-  title: ThreadTitleSchema,
-  isGenerating: ThreadIsGeneratingSchema
-});
+const AppServerGeneratedThreadListItemSchema = z
+  .object({
+    id: z.string().min(1),
+    preview: z.string(),
+    title: ThreadTitleSchema,
+    name: z.union([z.string(), z.null()]).optional(),
+    isGenerating: ThreadIsGeneratingSchema,
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative(),
+    cwd: z.string().optional(),
+    source: z.any().optional(),
+    modelProvider: z.string().optional(),
+    cliVersion: z.string().optional(),
+    path: z.union([z.string(), z.null()]).optional(),
+    gitInfo: z.any().optional(),
+    status: z.any().optional(),
+    turns: z.array(z.any()).optional()
+  })
+  .passthrough();
 
 const OpenCodeThreadListItemSchema = z
   .object({
@@ -79,18 +98,58 @@ export const AppServerReadThreadResponseSchema: z.ZodObject<
   })
   .passthrough();
 
-export const AppServerModelSchema = AppServerModelListResponseBaseSchema.shape.data.element;
+export const AppServerModelSchema = z
+  .object({
+    id: z.string().min(1),
+    model: z.string().min(1),
+    displayName: z.string().optional(),
+    description: z.string().optional(),
+    hidden: z.boolean().optional(),
+    supportedReasoningEfforts: z.array(AppServerModelReasoningEffortItemSchema).default([]),
+    defaultReasoningEffort: z.string().optional(),
+    inputModalities: z.array(z.any()).optional(),
+    supportsPersonality: z.boolean().optional(),
+    isDefault: z.boolean().optional(),
+    upgrade: z.union([z.string(), z.null()]).optional(),
+    upgradeInfo: z.any().optional(),
+    availabilityNux: z.any().optional()
+  })
+  .passthrough();
 
 export const AppServerModelReasoningEffortSchema =
-  AppServerModelSchema.shape.supportedReasoningEfforts.element;
+  AppServerModelReasoningEffortItemSchema;
 
-export const AppServerListModelsResponseSchema = AppServerModelListResponseBaseSchema;
+export const AppServerListModelsResponseSchema = z
+  .object({
+    data: z.array(AppServerModelSchema),
+    nextCursor: z.union([z.string(), z.null()]).optional()
+  })
+  .passthrough();
 
-export const AppServerCollaborationModeListItemSchema =
-  AppServerCollaborationModeListResponseBaseSchema.shape.data.element;
+export const AppServerCollaborationModeListItemSchema = z
+  .object({
+    name: z.string().optional(),
+    mode: z.string().optional(),
+    model: z.union([z.string(), z.null()]).optional(),
+    reasoning_effort: z.union([z.string(), z.null()]).optional(),
+    developer_instructions: z.union([z.string(), z.null()]).optional(),
+    settings: z
+      .object({
+        model: z.union([z.string(), z.null()]).optional(),
+        reasoning_effort: z.union([z.string(), z.null()]).optional(),
+        developer_instructions: z.union([z.string(), z.null()]).optional()
+      })
+      .passthrough()
+      .optional()
+  })
+  .passthrough();
 
-export const AppServerCollaborationModeListResponseSchema =
-  AppServerCollaborationModeListResponseBaseSchema;
+export const AppServerCollaborationModeListResponseSchema = z
+  .object({
+    data: z.array(AppServerCollaborationModeListItemSchema),
+    nextCursor: z.union([z.string(), z.null()]).optional()
+  })
+  .passthrough();
 
 export const AppServerStartThreadRequestSchema = AppServerStartThreadRequestBaseSchema;
 

--- a/packages/codex-protocol/src/thread.ts
+++ b/packages/codex-protocol/src/thread.ts
@@ -145,14 +145,21 @@ export const TodoListPlanStepSchema = z
   })
   .passthrough();
 
-export const TodoListItemSchema = z
+const TodoListItemBaseSchema = z
   .object({
     id: NonEmptyStringSchema,
-    type: z.literal("todo-list"),
-    explanation: z.string().optional(),
+    explanation: z.union([z.string(), z.null()]).optional(),
     plan: z.array(TodoListPlanStepSchema)
   })
   .passthrough();
+
+export const TodoListItemSchema = TodoListItemBaseSchema.extend({
+  type: z.literal("todo-list")
+});
+
+export const TodoListCamelItemSchema = TodoListItemBaseSchema.extend({
+  type: z.literal("todoList")
+});
 
 export const PlanImplementationItemSchema = z
   .object({
@@ -200,7 +207,7 @@ export const CommandExecutionItemSchema = z
     id: NonEmptyStringSchema,
     command: z.string(),
     cwd: z.string().optional(),
-    processId: z.string().optional(),
+    processId: z.union([z.string(), z.null()]).optional(),
     status: NonEmptyStringSchema,
     commandActions: z.array(CommandActionSchema).optional(),
     aggregatedOutput: z.union([z.string(), z.null()]).optional(),
@@ -313,6 +320,41 @@ export const McpToolCallItemSchema = z
   })
   .passthrough();
 
+export const DynamicToolCallContentItemSchema = z
+  .discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("inputText"),
+        text: z.string()
+      })
+      .passthrough(),
+    z
+      .object({
+        type: z.literal("inputImage"),
+        imageUrl: z.string()
+      })
+      .passthrough()
+  ]);
+
+export const DynamicToolCallStatusSchema = z.enum([
+  "inProgress",
+  "completed",
+  "failed"
+]);
+
+export const DynamicToolCallItemSchema = z
+  .object({
+    type: z.literal("dynamicToolCall"),
+    id: NonEmptyStringSchema,
+    tool: z.string(),
+    arguments: JsonValueSchema,
+    status: DynamicToolCallStatusSchema,
+    contentItems: z.union([z.array(DynamicToolCallContentItemSchema), z.null()]).optional(),
+    success: z.union([z.boolean(), z.null()]).optional(),
+    durationMs: z.union([NonNegativeIntSchema, z.null()]).optional()
+  })
+  .passthrough();
+
 export const CollabAgentToolSchema = z.enum([
   "spawnAgent",
   "sendInput",
@@ -384,6 +426,7 @@ export const TurnItemSchema = z.discriminatedUnion("type", [
   ReasoningItemSchema,
   PlanItemSchema,
   TodoListItemSchema,
+  TodoListCamelItemSchema,
   PlanImplementationItemSchema,
   UserInputResponseItemSchema,
   CommandExecutionItemSchema,
@@ -391,6 +434,7 @@ export const TurnItemSchema = z.discriminatedUnion("type", [
   ContextCompactionItemSchema,
   WebSearchItemSchema,
   McpToolCallItemSchema,
+  DynamicToolCallItemSchema,
   CollabAgentToolCallItemSchema,
   ImageViewItemSchema,
   EnteredReviewModeItemSchema,

--- a/packages/codex-protocol/test/protocol.test.ts
+++ b/packages/codex-protocol/test/protocol.test.ts
@@ -269,6 +269,49 @@ describe("codex-protocol schemas", () => {
     expect(todoItem?.type).toBe("todo-list");
   });
 
+  it("parses snapshot broadcast when turn includes todoList item", () => {
+    const parsed = parseThreadStreamStateChangedBroadcast({
+      type: "broadcast",
+      method: "thread-stream-state-changed",
+      sourceClientId: "client-123",
+      version: 4,
+      params: {
+        conversationId: "thread-123",
+        type: "thread-stream-state-changed",
+        version: 4,
+        change: {
+          type: "snapshot",
+          conversationState: {
+            id: "thread-123",
+            turns: [
+              {
+                status: "inProgress",
+                items: [
+                  {
+                    id: "todo-1",
+                    type: "todoList",
+                    explanation: null,
+                    plan: [
+                      { step: "Gather context", status: "completed" },
+                      { step: "Implement fix", status: "inProgress" }
+                    ]
+                  }
+                ]
+              }
+            ],
+            requests: []
+          }
+        }
+      }
+    });
+
+    expect(parsed.params.change.type).toBe("snapshot");
+    const todoItem = parsed.params.change.type === "snapshot"
+      ? parsed.params.change.conversationState.turns[0]?.items[0]
+      : null;
+    expect(todoItem?.type).toBe("todoList");
+  });
+
   it("parses snapshot broadcast when turn includes remoteTaskCreated item", () => {
     const parsed = parseThreadStreamStateChangedBroadcast({
       type: "broadcast",
@@ -655,7 +698,7 @@ describe("codex-protocol schemas", () => {
     expect(parsed.turns[0]?.items[1]?.type).toBe("webSearch");
   });
 
-  it("parses thread conversation state with mcp and collab tool call items", () => {
+  it("parses thread conversation state with mcp, dynamic, and collab tool call items", () => {
     const parsed = parseThreadConversationState({
       id: "thread-123",
       turns: [
@@ -675,6 +718,27 @@ describe("codex-protocol schemas", () => {
               },
               error: null,
               durationMs: 18
+            },
+            {
+              id: "item-dynamic",
+              type: "dynamicToolCall",
+              tool: "web_search",
+              status: "completed",
+              arguments: {
+                query: "farfield dynamic tool call"
+              },
+              contentItems: [
+                {
+                  type: "inputText",
+                  text: "Search complete"
+                },
+                {
+                  type: "inputImage",
+                  imageUrl: "https://example.com/image.png"
+                }
+              ],
+              success: true,
+              durationMs: 42
             },
             {
               id: "item-collab",
@@ -713,10 +777,11 @@ describe("codex-protocol schemas", () => {
     });
 
     expect(parsed.turns[0]?.items[0]?.type).toBe("mcpToolCall");
-    expect(parsed.turns[0]?.items[1]?.type).toBe("collabAgentToolCall");
-    expect(parsed.turns[0]?.items[2]?.type).toBe("imageView");
-    expect(parsed.turns[0]?.items[3]?.type).toBe("enteredReviewMode");
-    expect(parsed.turns[0]?.items[4]?.type).toBe("exitedReviewMode");
+    expect(parsed.turns[0]?.items[1]?.type).toBe("dynamicToolCall");
+    expect(parsed.turns[0]?.items[2]?.type).toBe("collabAgentToolCall");
+    expect(parsed.turns[0]?.items[3]?.type).toBe("imageView");
+    expect(parsed.turns[0]?.items[4]?.type).toBe("enteredReviewMode");
+    expect(parsed.turns[0]?.items[5]?.type).toBe("exitedReviewMode");
   });
 
   it("parses contextCompaction item when completed is omitted", () => {

--- a/packages/unified-surface/src/index.ts
+++ b/packages/unified-surface/src/index.ts
@@ -932,7 +932,7 @@ const UnifiedCommandCreateThreadSchema = z
   })
   .strict();
 
-const UnifiedCommandReadThreadSchema = z
+export const UnifiedCommandReadThreadSchema = z
   .object({
     kind: z.literal("readThread"),
     provider: UnifiedProviderIdSchema,
@@ -1010,7 +1010,7 @@ const UnifiedCommandSubmitUserInputSchema = z
   })
   .strict();
 
-const UnifiedCommandReadLiveStateSchema = z
+export const UnifiedCommandReadLiveStateSchema = z
   .object({
     kind: z.literal("readLiveState"),
     provider: UnifiedProviderIdSchema,

--- a/packages/unified-surface/src/index.ts
+++ b/packages/unified-surface/src/index.ts
@@ -689,6 +689,37 @@ const UnifiedMcpToolCallItemSchema = z
   })
   .strict();
 
+const UnifiedDynamicToolCallContentItemSchema = z
+  .discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("inputText"),
+        text: z.string()
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("inputImage"),
+        imageUrl: z.string()
+      })
+      .strict()
+  ]);
+
+const UnifiedDynamicToolCallItemSchema = z
+  .object({
+    id: NonEmptyStringSchema,
+    type: z.literal("dynamicToolCall"),
+    tool: z.string(),
+    status: z.enum(["inProgress", "completed", "failed"]),
+    arguments: JsonValueSchema,
+    contentItems: z
+      .union([z.array(UnifiedDynamicToolCallContentItemSchema), z.null()])
+      .optional(),
+    success: z.union([z.boolean(), z.null()]).optional(),
+    durationMs: z.union([NonNegativeIntSchema, z.null()]).optional()
+  })
+  .strict();
+
 const UnifiedCollabAgentToolCallItemSchema = z
   .object({
     id: NonEmptyStringSchema,
@@ -774,6 +805,7 @@ export const UnifiedItemSchema = z.discriminatedUnion("type", [
   UnifiedContextCompactionItemSchema,
   UnifiedWebSearchItemSchema,
   UnifiedMcpToolCallItemSchema,
+  UnifiedDynamicToolCallItemSchema,
   UnifiedCollabAgentToolCallItemSchema,
   UnifiedImageViewItemSchema,
   UnifiedEnteredReviewModeItemSchema,
@@ -801,6 +833,7 @@ export const UNIFIED_ITEM_KINDS = [
   "contextCompaction",
   "webSearch",
   "mcpToolCall",
+  "dynamicToolCall",
   "collabAgentToolCall",
   "imageView",
   "enteredReviewMode",
@@ -904,7 +937,8 @@ const UnifiedCommandReadThreadSchema = z
     kind: z.literal("readThread"),
     provider: UnifiedProviderIdSchema,
     threadId: NonEmptyStringSchema,
-    includeTurns: z.boolean().optional().default(true)
+    includeTurns: z.boolean().optional().default(true),
+    maxRenderableItems: z.number().int().positive().optional()
   })
   .strict();
 
@@ -980,7 +1014,8 @@ const UnifiedCommandReadLiveStateSchema = z
   .object({
     kind: z.literal("readLiveState"),
     provider: UnifiedProviderIdSchema,
-    threadId: NonEmptyStringSchema
+    threadId: NonEmptyStringSchema,
+    maxRenderableItems: z.number().int().positive().optional()
   })
   .strict();
 
@@ -1298,6 +1333,7 @@ const ITEM_KIND_COVERAGE: Record<UnifiedItemKind, true> = {
   contextCompaction: true,
   webSearch: true,
   mcpToolCall: true,
+  dynamicToolCall: true,
   collabAgentToolCall: true,
   imageView: true,
   enteredReviewMode: true,

--- a/scripts/generate-opencode-manifest.mjs
+++ b/scripts/generate-opencode-manifest.mjs
@@ -32,6 +32,10 @@ const outputPath = path.join(
   "OpenCodeManifest.ts"
 );
 
+function toPosixRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
 function assertSourceFile(filePath) {
   const program = ts.createProgram([filePath], {
     strict: true,
@@ -113,7 +117,7 @@ function renderTupleConstant(constantName, values) {
 function writeManifestFile(manifest) {
   const lines = [
     "// GENERATED FILE. DO NOT EDIT.",
-    `// Source: ${path.relative(repoRoot, sdkTypesPath)}`,
+    `// Source: ${toPosixRelative(sdkTypesPath)}`,
     "",
     renderTupleConstant("OPENCODE_EVENT_TYPES", manifest.eventTypes),
     "export type OpenCodeEventType = typeof OPENCODE_EVENT_TYPES[number];",


### PR DESCRIPTION
## Summary
- harden archived/live thread state handling and add runtime health counters
- tighten web chat/debug state retention, stale-load protection, and history labeling
- reduce large tool payload retention and add focused regression coverage for server and web

## Testing
- bun run --filter @farfield/server test
- bun run --filter @farfield/server typecheck
- bun run --filter @farfield/web test
- bun run --filter @farfield/web typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restore and view archived conversation sessions; show concise previews for dynamic tool-call results.
  * Request a maxRenderableItems limit to control chat view density and load older messages on demand.

* **Improvements**
  * Chat messages render text and image URLs; tool arguments/structured content are truncated previews.
  * History payloads are compacted and stored with size/compaction metadata; tracked-thread runtime metrics exposed.
  * Windows spawn/exec handling improved; favicon added; reduced default history retention.

* **Tests**
  * Expanded coverage for archived restores, compaction, trimming, spawn behavior, runtime retention, and UI/load ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->