### PR TITLE
Add token auth for safer remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,21 @@ You will need to make port 4311 remotely accessible via HTTPS and give the publi
 
 The securest way to open the port for remote access is by putting all devices involved in a private VPN. Tailscale is a free option that works.
 
-Doing this with Tailscale is as simple as installing Tailscale on your phone, computer, etc., and running this command on the device hosting the Farfield server:
+For an extra guardrail, set a token before starting the server:
+
+```bash
+export FARFIELD_AUTH_TOKEN="$(openssl rand -hex 32)"
+export FARFIELD_CORS_ORIGIN="https://farfield.app"
+npx -y @farfield/server@latest
+```
+
+Then install Tailscale on your phone, computer, etc., and run this command on the device hosting the Farfield server:
+
 ```bash
 tailscale serve --https=443 http://127.0.0.1:4311
 ```
+
+In farfield.app **Settings**, paste your Tailscale HTTPS URL into **Server** and paste the same token into **Auth token**.
 
 We are working on easier options. Stay tuned!
 
@@ -99,7 +110,7 @@ bun run dev:remote                           # exposes frontend + backend on you
 bun run dev:remote -- --agents=opencode      # remote mode with OpenCode only
 ```
 
-> **Warning:** `dev:remote` exposes Farfield with no authentication. Only use on trusted networks.
+> **Warning:** `dev:remote` exposes Farfield on your network. Set `FARFIELD_AUTH_TOKEN` and `FARFIELD_CORS_ORIGIN` when using it outside a trusted local network.
 
 ## Production Mode (No Extra Proxy)
 
@@ -180,13 +191,16 @@ You still need to run the server locally so it can talk to your coding agent.
 ### 1) Start the Farfield server on your machine
 
 ```bash
+export FARFIELD_AUTH_TOKEN="$(openssl rand -hex 32)"
+export FARFIELD_CORS_ORIGIN="https://farfield.app"
 HOST=0.0.0.0 PORT=4311 bun run --filter @farfield/server dev
 ```
 
 Quick local check:
 
 ```bash
-curl http://127.0.0.1:4311/api/health
+curl -H "Authorization: Bearer $FARFIELD_AUTH_TOKEN" \
+  http://127.0.0.1:4311/api/health
 ```
 
 ### 2) Put Tailscale HTTPS in front of port 4311
@@ -207,7 +221,8 @@ https://<machine>.<tailnet>.ts.net
 Check it from a device on your tailnet:
 
 ```bash
-curl https://<machine>.<tailnet>.ts.net/api/health
+curl -H "Authorization: Bearer $FARFIELD_AUTH_TOKEN" \
+  https://<machine>.<tailnet>.ts.net/api/health
 ```
 
 ### 3) Pair farfield.app to your server
@@ -221,15 +236,18 @@ https://<machine>.<tailnet>.ts.net
 (note: no port)
 ```
 
-4. Click **Save**.
+4. In **Auth token**, paste the value of `FARFIELD_AUTH_TOKEN`.
+5. Click **Save**.
 
-Farfield stores this in browser storage and uses it for API calls and live event stream.
+Farfield stores this in browser storage and uses it for API calls and realtime websocket auth.
 
 ### Notes
 
 - Do not use raw tailnet IPs with `https://` (for example `https://100.x.x.x:4311`) in the browser; this won't work.
 - If you use `tailscale serve --https=443`, do not include `:4311` in the URL you enter in Settings.
 - **Use automatic** in Settings clears the saved server URL and returns to built-in default behavior.
+- `FARFIELD_AUTH_TOKEN` accepts `Authorization: Bearer <token>` and `X-Farfield-Token: <token>`.
+- If you self-host the frontend, set `FARFIELD_CORS_ORIGIN` to your frontend origin instead of `https://farfield.app`.
 
 ## License
 

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,0 +1,84 @@
+import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
+
+export interface FarfieldAuthConfig {
+  token: string;
+  corsOrigin: string;
+}
+
+export function resolveFarfieldAuthConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): FarfieldAuthConfig {
+  const token = env["FARFIELD_AUTH_TOKEN"]?.trim() ?? "";
+  const corsOrigin =
+    env["FARFIELD_CORS_ORIGIN"]?.trim() ??
+    (token.length > 0 ? "https://farfield.app" : "*");
+
+  return {
+    token,
+    corsOrigin,
+  };
+}
+
+function readBearerToken(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const [scheme, token] = value.split(/\s+/, 2);
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return null;
+  }
+  return token;
+}
+
+function tokenMatches(value: unknown, expectedToken: string): boolean {
+  return (
+    typeof value === "string" &&
+    expectedToken.length > 0 &&
+    value === expectedToken
+  );
+}
+
+function directHeaderToken(headers: IncomingHttpHeaders): string | null {
+  const directHeader = headers["x-farfield-token"];
+  if (Array.isArray(directHeader)) {
+    return directHeader.find((value) => value.length > 0) ?? null;
+  }
+  return directHeader ?? null;
+}
+
+export function requestToken(req: IncomingMessage): string | null {
+  return directHeaderToken(req.headers) ?? readBearerToken(req.headers.authorization);
+}
+
+export function isHttpRequestAuthorized(
+  req: IncomingMessage,
+  config: FarfieldAuthConfig,
+): boolean {
+  if (config.token.length === 0) {
+    return true;
+  }
+  return tokenMatches(requestToken(req), config.token);
+}
+
+export function isSocketAuthorized(
+  auth: unknown,
+  headers: IncomingHttpHeaders,
+  config: FarfieldAuthConfig,
+): boolean {
+  if (config.token.length === 0) {
+    return true;
+  }
+
+  if (auth && typeof auth === "object" && "token" in auth) {
+    const token = (auth as { token?: unknown }).token;
+    if (tokenMatches(token, config.token)) {
+      return true;
+    }
+  }
+
+  return (
+    tokenMatches(directHeaderToken(headers), config.token) ||
+    tokenMatches(readBearerToken(headers.authorization), config.token)
+  );
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -34,6 +34,11 @@ import {
   TraceMarkBodySchema,
   TraceStartBodySchema,
 } from "./http-schemas.js";
+import {
+  isHttpRequestAuthorized,
+  isSocketAuthorized,
+  resolveFarfieldAuthConfig,
+} from "./auth.js";
 import { logger } from "./logger.js";
 import {
   parseServerCliOptions,
@@ -62,6 +67,7 @@ import {
 
 const HOST = process.env["HOST"] ?? "127.0.0.1";
 const PORT = Number(process.env["PORT"] ?? 4311);
+const AUTH_CONFIG = resolveFarfieldAuthConfig();
 const HISTORY_LIMIT = 2_000;
 const USER_AGENT = "farfield/0.2.5";
 const IPC_RECONNECT_DELAY_MS = 1_000;
@@ -230,8 +236,9 @@ function jsonResponse(
   res.writeHead(statusCode, {
     "Content-Type": "application/json; charset=utf-8",
     "Content-Length": encoded.length,
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "content-type",
+    "Access-Control-Allow-Origin": AUTH_CONFIG.corsOrigin,
+    "Access-Control-Allow-Headers":
+      "content-type, authorization, x-farfield-token",
     "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
   });
   res.end(encoded);
@@ -1327,6 +1334,21 @@ const server = http.createServer(async (req, res) => {
     const pathname = url.pathname;
     const segments = pathname.split("/").filter(Boolean);
 
+    if (
+      pathname.startsWith("/api/") &&
+      !isHttpRequestAuthorized(req, AUTH_CONFIG)
+    ) {
+      jsonResponse(res, 401, {
+        ok: false,
+        error: {
+          code: "unauthorized",
+          message:
+            "Farfield authentication failed. Set Authorization: Bearer <token> or X-Farfield-Token.",
+        },
+      });
+      return;
+    }
+
     if (req.method === "GET" && pathname === "/api/health") {
       jsonResponse(res, 200, {
         ok: true,
@@ -1762,7 +1784,7 @@ const server = http.createServer(async (req, res) => {
           "Content-Type": "application/x-ndjson",
           "Content-Length": data.length,
           "Content-Disposition": `attachment; filename="${trace.id}.ndjson"`,
-          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Origin": AUTH_CONFIG.corsOrigin,
         });
         res.end(data);
         return;
@@ -1819,9 +1841,23 @@ const io = new SocketServer(server, {
   path: "/api/unified/ws",
   transports: ["websocket"],
   cors: {
-    origin: "*",
+    origin: AUTH_CONFIG.corsOrigin,
     methods: ["GET", "POST"],
   },
+});
+
+io.use((socket, next) => {
+  if (
+    isSocketAuthorized(
+      socket.handshake.auth,
+      socket.handshake.headers,
+      AUTH_CONFIG,
+    )
+  ) {
+    next();
+    return;
+  }
+  next(new Error("Unauthorized"));
 });
 
 const realtimeCoordinator = new RealtimeCoordinator({

--- a/apps/server/test/auth.test.ts
+++ b/apps/server/test/auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { IncomingMessage } from "node:http";
+import {
+  isHttpRequestAuthorized,
+  isSocketAuthorized,
+  requestToken,
+  resolveFarfieldAuthConfig,
+} from "../src/auth.js";
+
+function requestWithHeaders(
+  headers: IncomingMessage["headers"],
+): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+describe("farfield auth", () => {
+  it("is disabled when FARFIELD_AUTH_TOKEN is not set", () => {
+    const config = resolveFarfieldAuthConfig({});
+
+    expect(config.token).toBe("");
+    expect(config.corsOrigin).toBe("*");
+    expect(isHttpRequestAuthorized(requestWithHeaders({}), config)).toBe(true);
+  });
+
+  it("uses farfield.app as the default cors origin when auth is enabled", () => {
+    const config = resolveFarfieldAuthConfig({
+      FARFIELD_AUTH_TOKEN: "secret",
+    });
+
+    expect(config.corsOrigin).toBe("https://farfield.app");
+  });
+
+  it("uses configured cors origin when provided", () => {
+    const config = resolveFarfieldAuthConfig({
+      FARFIELD_AUTH_TOKEN: "secret",
+      FARFIELD_CORS_ORIGIN: "https://phone.example.com",
+    });
+
+    expect(config.corsOrigin).toBe("https://phone.example.com");
+  });
+
+  it("authorizes bearer tokens", () => {
+    const config = resolveFarfieldAuthConfig({
+      FARFIELD_AUTH_TOKEN: "secret",
+    });
+
+    expect(
+      isHttpRequestAuthorized(
+        requestWithHeaders({ authorization: "Bearer secret" }),
+        config,
+      ),
+    ).toBe(true);
+  });
+
+  it("authorizes x-farfield-token headers", () => {
+    const config = resolveFarfieldAuthConfig({
+      FARFIELD_AUTH_TOKEN: "secret",
+    });
+
+    expect(
+      isHttpRequestAuthorized(
+        requestWithHeaders({ "x-farfield-token": "secret" }),
+        config,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects missing or incorrect tokens", () => {
+    const config = resolveFarfieldAuthConfig({
+      FARFIELD_AUTH_TOKEN: "secret",
+    });
+
+    expect(isHttpRequestAuthorized(requestWithHeaders({}), config)).toBe(false);
+    expect(
+      isHttpRequestAuthorized(
+        requestWithHeaders({ authorization: "Bearer wrong" }),
+        config,
+      ),
+    ).toBe(false);
+  });
+
+  it("extracts x-farfield-token before bearer auth", () => {
+    expect(
+      requestToken(
+        requestWithHeaders({
+          authorization: "Bearer wrong",
+          "x-farfield-token": "secret",
+        }),
+      ),
+    ).toBe("secret");
+  });
+
+  it("authorizes socket auth payloads", () => {
+    const config = resolveFarfieldAuthConfig({
+      FARFIELD_AUTH_TOKEN: "secret",
+    });
+
+    expect(isSocketAuthorized({ token: "secret" }, {}, config)).toBe(true);
+    expect(isSocketAuthorized({ token: "wrong" }, {}, config)).toBe(false);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,6 +39,7 @@ import {
   getPendingApprovalRequests,
   getPendingThreadRequests,
   getPendingUserInputRequests,
+  getSavedServerAuthToken,
   getSavedServerBaseUrl,
   getServerBaseUrl,
   getStreamEvents,
@@ -1342,6 +1343,7 @@ export function App(): React.JSX.Element {
     () => getSavedServerBaseUrl() !== null,
     [],
   );
+  const initialServerAuthToken = useMemo(() => getSavedServerAuthToken(), []);
   const initialSnapshot = ENABLE_VIEW_SNAPSHOT_CACHE
     ? appViewSnapshotCache
     : null;
@@ -1410,8 +1412,12 @@ export function App(): React.JSX.Element {
   );
   const [serverBaseUrl, setServerBaseUrlState] =
     useState<string>(initialServerBaseUrl);
+  const [serverAuthToken, setServerAuthToken] =
+    useState<string>(initialServerAuthToken);
   const [serverBaseUrlDraft, setServerBaseUrlDraft] =
     useState<string>(initialServerBaseUrl);
+  const [serverAuthTokenDraft, setServerAuthTokenDraft] =
+    useState<string>(initialServerAuthToken);
   const [hasSavedServerTarget, setHasSavedServerTarget] = useState<boolean>(
     initialHasSavedServerBaseUrl,
   );
@@ -1529,7 +1535,8 @@ export function App(): React.JSX.Element {
   const selectedAgentLabel = selectedAgentDescriptor?.label ?? "Agent";
   const reversedHistory = useMemo(() => history.slice().reverse(), [history]);
   const hasServerBaseUrlDraftChanges =
-    serverBaseUrlDraft.trim() !== serverBaseUrl;
+    serverBaseUrlDraft.trim() !== serverBaseUrl ||
+    serverAuthTokenDraft.trim() !== serverAuthToken;
   const unifiedWebSocketUrl = useMemo(
     () => getUnifiedWebSocketUrl(serverBaseUrl),
     [serverBaseUrl],
@@ -2721,9 +2728,13 @@ export function App(): React.JSX.Element {
   const saveServerTarget = useCallback(async () => {
     try {
       setError("");
-      const normalizedBaseUrl = setServerBaseUrl(serverBaseUrlDraft);
+      const normalizedBaseUrl = setServerBaseUrl(
+        serverBaseUrlDraft,
+        serverAuthTokenDraft,
+      );
       setServerBaseUrlState(normalizedBaseUrl);
       setServerBaseUrlDraft(normalizedBaseUrl);
+      setServerAuthToken(serverAuthTokenDraft.trim());
       setHasSavedServerTarget(true);
       agentCacheRef.current = null;
       providerCatalogCacheRef.current.clear();
@@ -2731,7 +2742,7 @@ export function App(): React.JSX.Element {
     } catch (e) {
       setError(toErrorMessage(e));
     }
-  }, [refreshAll, serverBaseUrlDraft]);
+  }, [refreshAll, serverAuthTokenDraft, serverBaseUrlDraft]);
 
   const useDefaultServerTarget = useCallback(async () => {
     try {
@@ -2740,6 +2751,8 @@ export function App(): React.JSX.Element {
       const defaultBaseUrl = getDefaultServerBaseUrl();
       setServerBaseUrlState(defaultBaseUrl);
       setServerBaseUrlDraft(defaultBaseUrl);
+      setServerAuthToken("");
+      setServerAuthTokenDraft("");
       setHasSavedServerTarget(false);
       agentCacheRef.current = null;
       providerCatalogCacheRef.current.clear();
@@ -3192,6 +3205,7 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     const socket = createUnifiedRealtimeSocket({
       socketUrl: unifiedWebSocketUrl,
+      authToken: serverAuthToken,
       onConnect: () => {
         socket.send({
           kind: "hello",
@@ -3248,7 +3262,7 @@ export function App(): React.JSX.Element {
       window.removeEventListener("pageshow", onPageShow);
       disconnectSocket();
     };
-  }, [handleRealtimeMessage, unifiedWebSocketUrl]);
+  }, [handleRealtimeMessage, serverAuthToken, unifiedWebSocketUrl]);
 
   useEffect(() => {
     if (!activeRequest) {
@@ -5467,6 +5481,27 @@ export function App(): React.JSX.Element {
                       }
                     }}
                     placeholder="https://your-vpn-server.example.com"
+                    className="h-9 text-sm"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label className="text-sm font-medium">Auth token</Label>
+                  <div className="text-xs text-muted-foreground">
+                    Optional. Must match FARFIELD_AUTH_TOKEN when your server
+                    enables token auth.
+                  </div>
+                  <Input
+                    type="password"
+                    value={serverAuthTokenDraft}
+                    onChange={(e) => setServerAuthTokenDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        void saveServerTarget();
+                      }
+                    }}
+                    placeholder="Paste FARFIELD_AUTH_TOKEN"
                     className="h-9 text-sm"
                   />
                 </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -449,12 +449,17 @@ export function getSavedServerBaseUrl(): string | null {
   return stored?.baseUrl ?? null;
 }
 
+export function getSavedServerAuthToken(): string {
+  const stored = readStoredServerTarget();
+  return stored?.authToken ?? "";
+}
+
 export function getDefaultServerBaseUrl(): string {
   return getDefaultStoredServerBaseUrl();
 }
 
-export function setServerBaseUrl(value: string): string {
-  return saveServerBaseUrl(value).baseUrl;
+export function setServerBaseUrl(value: string, authToken?: string): string {
+  return saveServerBaseUrl(value, authToken).baseUrl;
 }
 
 export function clearServerBaseUrl(): void {
@@ -473,7 +478,15 @@ async function requestJson(
   path: string,
   init?: RequestInit,
 ): Promise<{ response: Response; payload: JsonValue }> {
-  const response = await fetch(buildServerUrl(path), init);
+  const authToken = getSavedServerAuthToken();
+  const headers = new Headers(init?.headers);
+  if (authToken.length > 0 && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${authToken}`);
+  }
+  const response = await fetch(buildServerUrl(path), {
+    ...init,
+    headers,
+  });
   const payload = JsonValueSchema.parse(await response.json());
   return {
     response,

--- a/apps/web/src/lib/realtime-socket.ts
+++ b/apps/web/src/lib/realtime-socket.ts
@@ -18,6 +18,7 @@ export interface UnifiedRealtimeSocket {
 
 export function createUnifiedRealtimeSocket(input: {
   socketUrl: string;
+  authToken?: string;
   onMessage: (message: UnifiedRealtimeServerMessage) => void;
   onConnect?: () => void;
   onDisconnect?: () => void;
@@ -33,6 +34,9 @@ export function createUnifiedRealtimeSocket(input: {
       reconnection: true,
       reconnectionDelay: 1_000,
       reconnectionDelayMax: 10_000,
+      ...(input.authToken && input.authToken.length > 0
+        ? { auth: { token: input.authToken } }
+        : {}),
     },
   );
 

--- a/apps/web/src/lib/server-target.ts
+++ b/apps/web/src/lib/server-target.ts
@@ -52,6 +52,7 @@ const StoredServerTargetSchema = z
   .object({
     version: z.literal(1),
     baseUrl: ServerBaseUrlSchema,
+    authToken: z.string().trim().optional(),
   })
   .strict();
 
@@ -92,6 +93,11 @@ export function getDefaultServerBaseUrl(): string {
   return window.location.origin;
 }
 
+function normalizeAuthToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 export function readStoredServerTarget(): StoredServerTarget | null {
   if (typeof window === "undefined") {
     return null;
@@ -110,11 +116,16 @@ export function parseServerBaseUrl(value: string): string {
   return ServerBaseUrlSchema.parse(value);
 }
 
-export function saveServerBaseUrl(value: string): StoredServerTarget {
+export function saveServerBaseUrl(
+  value: string,
+  authToken?: string,
+): StoredServerTarget {
   const parsedBaseUrl = parseServerBaseUrl(value);
+  const parsedAuthToken = normalizeAuthToken(authToken);
   const next: StoredServerTarget = {
     version: 1,
     baseUrl: parsedBaseUrl,
+    ...(parsedAuthToken ? { authToken: parsedAuthToken } : {}),
   };
 
   if (typeof window !== "undefined") {

--- a/apps/web/test/realtime-socket.test.ts
+++ b/apps/web/test/realtime-socket.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { createUnifiedRealtimeSocket } from "../src/lib/realtime-socket";
+
+const { ioMock } = vi.hoisted(() => ({
+  ioMock: vi.fn(() => ({
+    on: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    emit: vi.fn(),
+  })),
+}));
+
+vi.mock("socket.io-client", () => ({
+  io: ioMock,
+}));
+
+describe("createUnifiedRealtimeSocket", () => {
+  it("passes the auth token to socket.io when configured", () => {
+    createUnifiedRealtimeSocket({
+      socketUrl: "wss://farfield.example.com/api/unified/ws",
+      authToken: "secret",
+      onMessage: vi.fn(),
+    });
+
+    expect(ioMock).toHaveBeenCalledWith(
+      "wss://farfield.example.com",
+      expect.objectContaining({
+        path: "/api/unified/ws",
+        auth: { token: "secret" },
+      }),
+    );
+  });
+});

--- a/apps/web/test/server-target.test.ts
+++ b/apps/web/test/server-target.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearStoredServerTarget,
+  readStoredServerTarget,
+  saveServerBaseUrl,
+} from "../src/lib/server-target";
+
+describe("server target storage", () => {
+  beforeEach(() => {
+    clearStoredServerTarget();
+  });
+
+  it("stores an optional auth token with the server target", () => {
+    saveServerBaseUrl("https://farfield.example.com", " secret ");
+
+    expect(readStoredServerTarget()).toEqual({
+      version: 1,
+      baseUrl: "https://farfield.example.com",
+      authToken: "secret",
+    });
+  });
+
+  it("omits empty auth tokens", () => {
+    saveServerBaseUrl("https://farfield.example.com", "   ");
+
+    expect(readStoredServerTarget()).toEqual({
+      version: 1,
+      baseUrl: "https://farfield.example.com",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add optional `FARFIELD_AUTH_TOKEN` protection for `/api/*` HTTP routes and the `/api/unified/ws` realtime websocket
- replace hardcoded wildcard response/websocket CORS with `FARFIELD_CORS_ORIGIN` when serving responses
- add farfield.app Settings support for saving an auth token and sending it over HTTP + Socket.IO
- document the Tailscale + token setup as a lighter-weight default path than a full Cloudflare Access deployment

## Context
This is a smaller core alternative/complement to #10 for the security concerns in #28 and the remote password/sign-in request in #12. Cloudflare Access is still a stronger advanced deployment option, but this gives users a built-in guardrail for the common hosted-frontend + Tailscale flow.

## Verification
- `npx --yes bun@1.3.6 run prepare:workspace-dist`
- `npx --yes bun@1.3.6 run --filter @farfield/server test`
- `npx --yes bun@1.3.6 run --filter @farfield/web test`
- `npx --yes bun@1.3.6 run --filter @farfield/server typecheck`
- `npx --yes bun@1.3.6 run --filter @farfield/web typecheck`
- `npx --yes bun@1.3.6 run --filter @farfield/server build`
- `npx --yes bun@1.3.6 run --filter @farfield/web build`
- `git diff --check`

## Notes
- This PR is draft because the maintainer may prefer a different auth mode name or may want it folded into #10.
- The default remains no auth for local-only use; token enforcement starts when `FARFIELD_AUTH_TOKEN` is set.
- With token auth enabled and no `FARFIELD_CORS_ORIGIN`, the default CORS origin is `https://farfield.app`; self-hosted frontends should set `FARFIELD_CORS_ORIGIN` explicitly.